### PR TITLE
switch import path to lf-edge from zededa

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: all build build-docker build-local fmt clean lint test vet image
 
-IMG ?= zededa/adam
+IMG ?= lfedge/adam
 HASH ?= $(shell git show --format=%T -s)
 GOVER ?= 1.12.4-alpine3.9
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ which will run Adam, listening on the default port of `8080` (it will tell you w
 If you prefer to run Adam as a docker container:
 
 ```
-docker run zededa/adam server
+docker run lfedge/adam server
 ```
 
-You can add any of the options that would exist with a local Adam installation, including help: `docker run zededa/adam server --help`.
+You can add any of the options that would exist with a local Adam installation, including help: `docker run lfedge/adam server --help`.
 
 Note that when running in a docker container, directories are ephemeral. If you want to keep the directories, you should bind-mount them into your container. To make things easier, this repository includes a sample `docker-compose.yml` which runs adam, maps port `8080` in the container to `8080` on your host, and mounts the current directory's `./run/adam/` to the default `/adam/run/adam/` in the container.
 

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -15,7 +15,7 @@ import (
 	"path"
 
 	"github.com/spf13/cobra"
-	"github.com/zededa/adam/pkg/server"
+	"github.com/lf-edge/adam/pkg/server"
 )
 
 var (

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -10,7 +10,7 @@ import (
 	"path"
 
 	"github.com/spf13/cobra"
-	"github.com/zededa/adam/pkg/x509"
+	"github.com/lf-edge/adam/pkg/x509"
 )
 
 const (

--- a/cmd/onboard.go
+++ b/cmd/onboard.go
@@ -14,8 +14,8 @@ import (
 	"path"
 
 	"github.com/spf13/cobra"
-	"github.com/zededa/adam/pkg/server"
-	ax "github.com/zededa/adam/pkg/x509"
+	"github.com/lf-edge/adam/pkg/server"
+	ax "github.com/lf-edge/adam/pkg/x509"
 )
 
 var (

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -12,8 +12,8 @@ import (
 	"path"
 
 	"github.com/spf13/cobra"
-	"github.com/zededa/adam/pkg/driver"
-	"github.com/zededa/adam/pkg/server"
+	"github.com/lf-edge/adam/pkg/driver"
+	"github.com/lf-edge/adam/pkg/server"
 )
 
 const (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ version: '3'
 services:
   adam:
     build: .
-    image: zededa/adam
+    image: lfedge/adam
     ports:
       - "8080:8080"
     volumes:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zededa/adam
+module github.com/lf-edge/adam
 
 go 1.12
 

--- a/go.sum
+++ b/go.sum
@@ -226,7 +226,6 @@ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljT
 github.com/ugorji/go/codec v1.1.5-pre/go.mod h1:tULtS6Gy1AE1yCENaw4Vb//HLH5njI2tfCQDUqRd8fI=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/zededa/eve v0.0.0-20190510150552-c7efbf4236ba h1:o/O1cC13YO9prmVLjNP15LpHrDUtdoeUyPwIeIbL4dE=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	"github.com/zededa/adam/cmd"
+	"github.com/lf-edge/adam/cmd"
 )
 
 func main() {

--- a/pkg/driver/device_manager_file.go
+++ b/pkg/driver/device_manager_file.go
@@ -21,7 +21,7 @@ import (
 	"github.com/lf-edge/eve/api/go/logs"
 	"github.com/lf-edge/eve/api/go/metrics"
 	uuid "github.com/satori/go.uuid"
-	ax "github.com/zededa/adam/pkg/x509"
+	ax "github.com/lf-edge/adam/pkg/x509"
 )
 
 const (

--- a/pkg/driver/device_manager_file_test.go
+++ b/pkg/driver/device_manager_file_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/lf-edge/eve/api/go/logs"
 	"github.com/lf-edge/eve/api/go/metrics"
 	"github.com/satori/go.uuid"
-	ax "github.com/zededa/adam/pkg/x509"
+	ax "github.com/lf-edge/adam/pkg/x509"
 )
 
 func TestDeviceManagerFile(t *testing.T) {

--- a/pkg/driver/device_manager_memory_test.go
+++ b/pkg/driver/device_manager_memory_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/api/go/logs"
 	"github.com/lf-edge/eve/api/go/metrics"
-	ax "github.com/zededa/adam/pkg/x509"
+	ax "github.com/lf-edge/adam/pkg/x509"
 )
 
 func TestDeviceManagerMemory(t *testing.T) {

--- a/pkg/server/adminHandler.go
+++ b/pkg/server/adminHandler.go
@@ -14,8 +14,8 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/lf-edge/eve/api/go/config"
 	"github.com/satori/go.uuid"
-	"github.com/zededa/adam/pkg/driver"
-	ax "github.com/zededa/adam/pkg/x509"
+	"github.com/lf-edge/adam/pkg/driver"
+	ax "github.com/lf-edge/adam/pkg/x509"
 )
 
 type adminHandler struct {

--- a/pkg/server/apiHandler.go
+++ b/pkg/server/apiHandler.go
@@ -16,7 +16,7 @@ import (
 	"github.com/lf-edge/eve/api/go/logs"
 	"github.com/lf-edge/eve/api/go/metrics"
 	"github.com/lf-edge/eve/api/go/register"
-	"github.com/zededa/adam/pkg/driver"
+	"github.com/lf-edge/adam/pkg/driver"
 )
 
 type apiHandler struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,7 +12,7 @@ import (
 	"os"
 
 	"github.com/gorilla/mux"
-	"github.com/zededa/adam/pkg/driver"
+	"github.com/lf-edge/adam/pkg/driver"
 )
 
 // Server an adam server

--- a/pkg/x509/generate.go
+++ b/pkg/x509/generate.go
@@ -38,7 +38,7 @@ func Generate(cn, hosts string) ([]byte, *rsa.PrivateKey, error) {
 	notAfter := notBefore.Add(oneYear)
 
 	subject := pkix.Name{
-		Organization: []string{"Zededa"},
+		Organization: []string{"LFEdge"},
 	}
 	if cn != "" {
 		subject.CommonName = cn

--- a/pkg/x509/generate_test.go
+++ b/pkg/x509/generate_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"crypto/x509"
-	ax "github.com/zededa/adam/pkg/x509"
+	ax "github.com/lf-edge/adam/pkg/x509"
 )
 
 func TestGenerate(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

adam was moved over from `zededa/adam` to `lf-edge/adam`. This changes all of the go import paths, `go.{mod,sum}`, `Makefile`, `README`, etc. to be compliant.