### PR TITLE
implement endpoint for probe

### DIFF
--- a/pkg/server/apiHandler.go
+++ b/pkg/server/apiHandler.go
@@ -86,6 +86,11 @@ func (h *apiHandler) register(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 }
 
+func (h *apiHandler) probe(w http.ResponseWriter, r *http.Request) {
+	log.Printf("%s requested probe", r.RemoteAddr)
+	w.WriteHeader(http.StatusOK)
+}
+
 func (h *apiHandler) ping(w http.ResponseWriter, r *http.Request) {
 	// only uses the device cert
 	cert := getClientCert(r)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -55,6 +55,8 @@ func (s *Server) Start() {
 		manager: s.DeviceManager,
 	}
 
+	router.HandleFunc("/", api.probe).Methods("GET")
+
 	ed := router.PathPrefix("/api/v1/edgedevice").Subrouter()
 	ed.Use(ensureMTLS)
 	ed.Use(logRequest)


### PR DESCRIPTION
Implement endpoint for [probe](https://github.com/lf-edge/eve/blob/8e65a16ff2ebd7ef5d88c03bc395e006e707bcb4/pkg/pillar/cmd/zedrouter/probe.go#L397) 