### PR TITLE
Introducing EVE+Adam embedded mode of running Adam

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,10 @@ ARG GOARCH=amd64
 
 RUN go build -o /adam/bin/adam main.go
 
-FROM scratch
+FROM alpine:3.11
 
-COPY --from=build /adam/bin/adam /adam/bin/adam
+COPY scripts /bin
+COPY samples /adam
+COPY --from=build /adam/bin/adam /bin/
 WORKDIR /adam
-ENTRYPOINT ["/adam/bin/adam"]
-
+ENTRYPOINT ["/bin/adam"]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ docker run -v $PWD/run:/adam/run -p 8080:8080 lfedge/adam server
 
 By default, `adam` listens on port `8080`, but can be configured. Run `adam server --help`.
 
+Finally, you can embed Adam container into an EVE root filesystem creating an EVE instance that can be controlled externally by clients talking to Adam and Adam relaying it to EVE. This comes very handy in testing and any other situation where turning EVE's configuration pull model into a push one makes sense. Note that this deployment mode forever commits a single Adam instance to a single EVE instance and all the communication between EVE and Adam happen via localhost on the running EVE edge node. Adam container has a script [eve-embedded.sh](scripts/eve-embedded.sh) that orchestrates this bond and the Adam container can be used to build EVE image via the following stanza in EVE's image YAML file:
+
+```
+   - name: adam
+     image: lfedge/adam:latest
+     binds:
+        - /var/persist:/persist
+        - /var/config:/config
+     command: ["/bin/eve-embedded.sh"]
+     net: host
+```
+
 ## Building Adam
 
 Building Adam is straightforward:

--- a/samples/simple.json
+++ b/samples/simple.json
@@ -1,0 +1,128 @@
+{
+    "manufacturer": "Linux Foundation Edge",
+    "productName": "EVE",
+    "reboot": {
+        "counter": 1000,
+        "desiredState": true
+    },
+    "configItems": [
+        {
+            "key": "timer.port.testbetterinterval",
+            "value": "600"
+        },
+	{
+	    "key": "debug.enable.ssh",
+	    "value": "EVE_SSH_KEY"
+	}
+    ],
+    "networks": [
+        {
+            "id": "2e6038c1-ece6-4ffd-b95b-a7302c219d59",
+            "type": 4,
+            "ip": {
+                "dhcp": 4,
+                "dhcpRange": {}
+            },
+            "wireless": {}
+        }
+    ],
+    "systemAdapterList": [
+        {
+            "name": "eth0",
+            "uplink": true,
+            "networkUUID": "2e6038c1-ece6-4ffd-b95b-a7302c219d59"
+        }
+    ],
+    "lispInfo": {
+        "LispMapServers": [
+            {
+                "NameOrIp": "zedcontrol.alpha.zededa.net",
+                "Credential": "zededa-lispers.net"
+            }
+        ],
+        "LispInstance": 1000,
+        "EID": "fdf5:958d:25af:1753:d1a9:28e:ea99:1ef",
+        "EIDHashLen": 120,
+        "ZedServers": [
+            {
+                "HostName": "hikey02",
+                "EID": [
+                    "fdfd:ceef:cf85:7e40:6d4f:2181:ba06:e668"
+                ]
+            },
+            {
+                "HostName": "hikey04",
+                "EID": [
+                    "fd12:df08:d686:602d:2145:f7cf:2382:1683"
+                ]
+            },
+            {
+                "HostName": "hikey05",
+                "EID": [
+                    "fd81:abc5:7d7e:bcd7:40d9:df2c:be4b:600"
+                ]
+            },
+            {
+                "HostName": "zedbobo",
+                "EID": [
+                    "fdd5:79bf:7261:d9df:aea1:c8d2:842d:b99b"
+                ]
+            },
+            {
+                "HostName": "zedcontrol",
+                "EID": [
+                    "fd45:efca:3607:4c1d:eace:a947:3464:d21e"
+                ]
+            },
+            {
+                "HostName": "zedlake",
+                "EID": [
+                    "fd45:efca:3607:4c1d:eace:a947:3464:d21e"
+                ]
+            }
+        ],
+        "EidAllocationPrefix": "/Q==",
+        "EidAllocationPrefixLen": 8
+    },
+    "deviceIoList": [
+        {
+            "ptype": 1,
+            "phylabel": "eth0",
+            "phyaddrs": {
+                "Ifname": "eth0"
+            },
+            "logicallabel": "eth0",
+            "assigngrp": "eth0",
+            "usage": 1,
+            "usagePolicy": {
+                "freeUplink": true
+            }
+        }
+    ],
+    "networkInstances": [
+        {
+            "uuidandversion": {
+                "uuid": "ee2034ba-b520-47f5-b8c6-314b80289c0a"
+            },
+            "displayname": "defaultLocal-eve",
+            "instType": 2,
+            "activate": true,
+            "port": {
+                "name": "uplink"
+            },
+            "cfg": {},
+            "ipType": 1,
+            "ip": {
+                "subnet": "10.1.0.0/16",
+                "gateway": "10.1.0.1",
+                "dns": [
+                    "10.1.0.1"
+                ],
+                "dhcpRange": {
+                    "start": "10.1.0.2",
+                    "end": "10.1.255.254"
+                }
+            }
+        }
+    ]
+}

--- a/scripts/eve-embedded.sh
+++ b/scripts/eve-embedded.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# 
+# This script assumes that we're running together with EVE services
+# and thus have access to the following folders:
+#    /config  - containing all the usual EVE configuration files, to wit:
+#      * /config/root-certificate.pem (getting replaced by Adam's cert)
+#      * /config/server (getting replaced by Adam's local URL)
+#      * /config/device.cert.pem (Adam waits for it to show up so it can be registered)
+#    /persist - a persistent storage medium where we can keep our state
+set -x
+
+PORT=6000
+DB=/persist/adam
+
+SERVER=localhost:$PORT
+SERVER_URL=https://$SERVER
+
+bootstrap() {
+   ADAM_CMD="adam admin --server $SERVER_URL --server-ca $DB/server.pem"
+   # first make sure to register ourselves, skipping onboarding step
+   #   adam admin onboard add  --path /config/onboard.cert.pem --serial '*'
+   while true; do
+      sleep 10
+      if [ -f /config/device.cert.pem ]; then
+         $ADAM_CMD device add --path /config/device.cert.pem && break
+      fi
+   done
+
+   # then lets see what should be our default config
+   cp /config/adam.json /adam/default.json || cp /adam/simple.json /adam/default.json
+   if [ $(wc -l < /config/authorized_keys) -eq 1 ]; then
+      sed -ie 's#EVE_SSH_KEY#'"$(cat /config/authorized_keys)"'#' /adam/default.json
+   fi
+   UUID=$($ADAM_CMD device list | head -1)
+   if [ -n "$UUID" ]; then
+      # FIXME: this ugly hack is going away soon
+      sed -ie '1s#^{$#{"id":{"uuid":"'$UUID'","version":"5"},#' /adam/default.json
+      $ADAM_CMD device config set --uuid $UUID --config-path /adam/default.json
+   fi
+}
+
+# if this is the first run on this /persist -- generate everything
+if [ ! -d $DB ]; then
+   adam generate --db-url $DB --server --hosts 127.0.0.1,localhost --cn localhost.localdomain
+   cp $DB/server.pem /config/root-certificate.pem
+   echo $SERVER > /config/server
+   bootstrap &
+fi
+
+adam server --port $PORT --db-url $DB --conf-dir $DB/eve-conf --server-cert $DB/server.pem --server-key $DB/server-key.pem


### PR DESCRIPTION
This PR introduced an extra mode of running Adam in an environment where it is running on the same VM with all the rest of the EVE services. This is useful in variety of different scenarios to make EVE+Adam pair self-contained and available to accept push configuration instead of pull one. For example, the way I'm using this right now is  by building EVE rootfs image with the following extra section in the `services:` block:

```
  - name: adam
     image: lfedge/adam:latest
     binds:
        - /var/config:/config
        - /var/persist:/persist
     command: ["/bin/eve-embedded.sh"]
```  