### PR TITLE
default options for updating version and id

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"path"
 
-	"github.com/spf13/cobra"
 	"github.com/lf-edge/adam/pkg/x509"
+	"github.com/spf13/cobra"
 )
 
 const (

--- a/cmd/onboard.go
+++ b/cmd/onboard.go
@@ -13,9 +13,9 @@ import (
 	"os"
 	"path"
 
-	"github.com/spf13/cobra"
 	"github.com/lf-edge/adam/pkg/server"
 	ax "github.com/lf-edge/adam/pkg/x509"
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -11,9 +11,9 @@ import (
 	"os"
 	"path"
 
-	"github.com/spf13/cobra"
 	"github.com/lf-edge/adam/pkg/driver"
 	"github.com/lf-edge/adam/pkg/server"
+	"github.com/spf13/cobra"
 )
 
 const (

--- a/pkg/driver/device_manager_file.go
+++ b/pkg/driver/device_manager_file.go
@@ -888,7 +888,7 @@ func (d *DeviceManagerFile) GetLogsReader(u uuid.UUID) (io.Reader, error) {
 	}
 	deviceLogsDir := path.Join(d.getDevicePath(u), logDir)
 	dr := &DirReader{
-		Path: deviceLogsDir,
+		Path:     deviceLogsDir,
 		LineFeed: true,
 	}
 	return dr, nil
@@ -902,7 +902,7 @@ func (d *DeviceManagerFile) GetInfoReader(u uuid.UUID) (io.Reader, error) {
 	}
 	deviceInfoDir := path.Join(d.getDevicePath(u), infoDir)
 	dr := &DirReader{
-		Path: deviceInfoDir,
+		Path:     deviceInfoDir,
 		LineFeed: true,
 	}
 	return dr, nil

--- a/pkg/driver/device_manager_file_test.go
+++ b/pkg/driver/device_manager_file_test.go
@@ -15,11 +15,11 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
+	ax "github.com/lf-edge/adam/pkg/x509"
 	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/api/go/logs"
 	"github.com/lf-edge/eve/api/go/metrics"
 	"github.com/satori/go.uuid"
-	ax "github.com/lf-edge/adam/pkg/x509"
 )
 
 func TestDeviceManagerFile(t *testing.T) {

--- a/pkg/driver/device_manager_memory_test.go
+++ b/pkg/driver/device_manager_memory_test.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 	"testing"
 
+	ax "github.com/lf-edge/adam/pkg/x509"
 	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/api/go/logs"
 	"github.com/lf-edge/eve/api/go/metrics"
-	ax "github.com/lf-edge/adam/pkg/x509"
 )
 
 func TestDeviceManagerMemory(t *testing.T) {


### PR DESCRIPTION
Fixes #10 

Behaviour is as follows:

* if config contains UUID and it does not match the existing one: error
* if config does not contain UUID: insert automatically
* if config contains version: override the existing one
* if config does not contain version and the existing one is an integer: increment and insert
* if config does not contain version and the existing one is not an integer: error

