### PR TITLE
handle write errors sanely

### DIFF
--- a/cmd/device.go
+++ b/cmd/device.go
@@ -214,9 +214,13 @@ var deviceConfigSetCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("unable to create new http request: %v", err)
 		}
-		_, err = client.Do(req)
+		res, err := client.Do(req)
 		if err != nil {
 			log.Fatalf("error PUT URL %s: %v", u, err)
+		}
+		if res.StatusCode != 200 {
+			b, _ := ioutil.ReadAll(res.Body)
+			log.Fatalf("error PUT URL %s: %d %s", u, res.StatusCode, string(b))
 		}
 	},
 }


### PR DESCRIPTION
For some reason, we were ignoring http errors in the client on setting a new config. This fixes it.