### PR TITLE
fix bigdata driver and unify implementation

### DIFF
--- a/pkg/driver/common/common.go
+++ b/pkg/driver/common/common.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/lf-edge/eve/api/go/config"
@@ -26,7 +27,7 @@ const (
 
 type BigData interface {
 	Get(index int) ([]byte, error)
-	Read(p []byte) (int, error)
+	Reader() (io.Reader, error)
 	Write(b []byte) (int, error)
 }
 

--- a/pkg/driver/file/device_manager_file.go
+++ b/pkg/driver/file/device_manager_file.go
@@ -118,11 +118,11 @@ func (m *ManagedFile) Write(b []byte) (int, error) {
 	return written, nil
 }
 
-func (m *ManagedFile) Read(p []byte) (int, error) {
-	if m.dirReader == nil {
-
-	}
-	return 0, nil
+func (m *ManagedFile) Reader() (io.Reader, error) {
+	return &DirReader{
+		Path:     m.dir,
+		LineFeed: true,
+	}, nil
 }
 
 // DeviceManager implementation of DeviceManager interface with a directory as the backing store
@@ -1063,11 +1063,7 @@ func (d *DeviceManager) GetLogsReader(u uuid.UUID) (io.Reader, error) {
 	if !d.deviceExists(u) {
 		return nil, fmt.Errorf("unregistered device UUID: %s", u)
 	}
-	dr := &DirReader{
-		Path:     d.devices[u].Logs.(*ManagedFile).dir,
-		LineFeed: true,
-	}
-	return dr, nil
+	return d.devices[u].Logs.Reader()
 }
 
 // GetInfoReader get the info for a given uuid
@@ -1076,11 +1072,7 @@ func (d *DeviceManager) GetInfoReader(u uuid.UUID) (io.Reader, error) {
 	if !d.deviceExists(u) {
 		return nil, fmt.Errorf("unregistered device UUID: %s", u)
 	}
-	dr := &DirReader{
-		Path:     d.devices[u].Info.(*ManagedFile).dir,
-		LineFeed: true,
-	}
-	return dr, nil
+	return d.devices[u].Info.Reader()
 }
 
 // GetRequestsReader get the requests for a given uuid
@@ -1089,9 +1081,5 @@ func (d *DeviceManager) GetRequestsReader(u uuid.UUID) (io.Reader, error) {
 	if !d.deviceExists(u) {
 		return nil, fmt.Errorf("unregistered device UUID: %s", u)
 	}
-	dr := &DirReader{
-		Path:     d.devices[u].Requests.(*ManagedFile).dir,
-		LineFeed: true,
-	}
-	return dr, nil
+	return d.devices[u].Requests.Reader()
 }

--- a/pkg/driver/memory/device_manager_memory.go
+++ b/pkg/driver/memory/device_manager_memory.go
@@ -437,7 +437,7 @@ func (d *DeviceManager) GetLogsReader(u uuid.UUID) (io.Reader, error) {
 	if !ok {
 		return nil, fmt.Errorf("unregistered device UUID %s", u.String())
 	}
-	return dev.Logs, nil
+	return dev.Logs.Reader()
 }
 
 // GetInfoReader get the info for a given uuid
@@ -447,7 +447,7 @@ func (d *DeviceManager) GetInfoReader(u uuid.UUID) (io.Reader, error) {
 	if !ok {
 		return nil, fmt.Errorf("unregistered device UUID %s", u.String())
 	}
-	return dev.Info, nil
+	return dev.Info.Reader()
 }
 
 // GetRequestsReader get the requests for a given uuid
@@ -457,5 +457,5 @@ func (d *DeviceManager) GetRequestsReader(u uuid.UUID) (io.Reader, error) {
 	if !ok {
 		return nil, fmt.Errorf("unregistered device UUID %s", u.String())
 	}
-	return dev.Requests, nil
+	return dev.Requests.Reader()
 }


### PR DESCRIPTION
Does two things:

* unifies the Redis backend driver's usage of `BigData struct` for (logs, info, metrics, requests) to be aligned with the others (file, memory). In the process, eliminates a lot of duplication
* fixes where the `BigData struct` had a `Read()` call that never was used. Cleans it up to be a `Reader()` and get a standard `io.Reader()`

Once this is in, will enable it to get reader for, say, "last 5 entries".