### PR TITLE
switch from protobuf to bytes; deprecate jsonpb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,6 @@ require (
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.2.2
 	github.com/vmihailenco/msgpack/v4 v4.3.11
-	google.golang.org/protobuf v1.21.0 // indirect
+	google.golang.org/protobuf v1.21.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,7 @@ github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:x
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0 h1:aRz0NBceriICVtjhCgKkDvl+RudKu1CT6h0ZvUTrNfE=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
+github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
@@ -137,6 +138,7 @@ google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQ
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0 h1:qdOKuR/EIArgaWNjetjgTzgVTAZ+S/WXVrq9HW9zimw=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
+google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=

--- a/pkg/driver/device_manager.go
+++ b/pkg/driver/device_manager.go
@@ -8,10 +8,6 @@ import (
 	"io"
 
 	"github.com/lf-edge/adam/pkg/driver/common"
-	"github.com/lf-edge/eve/api/go/config"
-	"github.com/lf-edge/eve/api/go/info"
-	"github.com/lf-edge/eve/api/go/logs"
-	"github.com/lf-edge/eve/api/go/metrics"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -66,23 +62,21 @@ type DeviceManager interface {
 	// DeviceList list all of the known UUIDs for devices
 	DeviceList() ([]*uuid.UUID, error)
 	// DeviceRegister register a new device certificate, including the onboarding certificate used to register it and its serial
-	DeviceRegister(*x509.Certificate, *x509.Certificate, string) (*uuid.UUID, error)
+	DeviceRegister(uuid.UUID, *x509.Certificate, *x509.Certificate, string, []byte) error
 	// WriteInfo write an information message
-	WriteInfo(*info.ZInfoMsg) error
-	// WriteLogs write a LogBundle message
-	WriteLogs(*logs.LogBundle) error
+	WriteInfo(uuid.UUID, []byte) error
+	// WriteLogs write log messages
+	WriteLogs(uuid.UUID, []byte) error
 	// WriteAppInstanceLogs write a AppInstanceLogBundle message for instanceID
-	WriteAppInstanceLogs(instanceID uuid.UUID, deviceID uuid.UUID, m *logs.AppInstanceLogBundle) error
+	WriteAppInstanceLogs(instanceID uuid.UUID, deviceID uuid.UUID, b []byte) error
 	// WriteMetrics write a MetricMsg
-	WriteMetrics(*metrics.ZMetricMsg) error
+	WriteMetrics(uuid.UUID, []byte) error
 	// WriteRequest record a request that was made, including the remote IP, x-forwarded-for header, and path
-	WriteRequest(common.ApiRequest) error
+	WriteRequest(uuid.UUID, []byte) error
 	// GetConfig get the config for a given uuid
-	GetConfig(uuid.UUID) (*config.EdgeDevConfig, error)
+	GetConfig(uuid.UUID) ([]byte, error)
 	// SetConfig set the config for a given uuid
-	SetConfig(uuid.UUID, *config.EdgeDevConfig) error
-	// GetConfig get the config for a given uuid
-	GetConfigResponse(uuid.UUID) (*config.ConfigResponse, error)
+	SetConfig(uuid.UUID, []byte) error
 	// GetLogsReader get the logs for a given uuid
 	GetLogsReader(u uuid.UUID) (io.Reader, error)
 	// GetInfoReader get the info for a given uuid

--- a/pkg/driver/device_managers_test.go
+++ b/pkg/driver/device_managers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/lf-edge/adam/pkg/driver"
+	"github.com/lf-edge/adam/pkg/driver/common"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -13,7 +14,7 @@ func TestURLs(t *testing.T) {
 		t.Run("redis-url", func(t *testing.T) {
 			var mgr driver.DeviceManager
 			for _, mgr = range driver.GetDeviceManagers() {
-				if ok, _ := mgr.Init(url, 0, 0, 0, 0); ok {
+				if ok, _ := mgr.Init(url, common.MaxSizes{}); ok {
 					break
 				}
 			}
@@ -26,7 +27,7 @@ func TestURLs(t *testing.T) {
 		t.Run("non-redis-url", func(t *testing.T) {
 			var mgr driver.DeviceManager
 			for _, mgr = range driver.GetDeviceManagers() {
-				if ok, _ := mgr.Init(url, 0, 0, 0, 0); ok {
+				if ok, _ := mgr.Init(url, common.MaxSizes{}); ok {
 					break
 				}
 			}

--- a/pkg/server/apiHandler.go
+++ b/pkg/server/apiHandler.go
@@ -4,45 +4,68 @@
 package server
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/pem"
-	"github.com/gorilla/mux"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
 	"time"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/gorilla/mux"
 	"github.com/lf-edge/adam/pkg/driver"
 	"github.com/lf-edge/adam/pkg/driver/common"
+	"github.com/lf-edge/eve/api/go/config"
 	"github.com/lf-edge/eve/api/go/info"
 	"github.com/lf-edge/eve/api/go/logs"
 	"github.com/lf-edge/eve/api/go/metrics"
 	"github.com/lf-edge/eve/api/go/register"
 	uuid "github.com/satori/go.uuid"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
+
+type ApiRequest struct {
+	Timestamp time.Time `json:"timestamp"`
+	UUID      uuid.UUID `json:"uuid,omitempty"`
+	ClientIP  string    `json:"client-ip"`
+	Forwarded string    `json:"forwarded,omitempty"`
+	Method    string    `json:"method"`
+	URL       string    `json:"url"`
+}
 
 type apiHandler struct {
 	manager     driver.DeviceManager
-	logChannel  chan proto.Message
-	infoChannel chan proto.Message
+	logChannel  chan []byte
+	infoChannel chan []byte
 }
 
 func (h *apiHandler) recordClient(u *uuid.UUID, r *http.Request) {
-	var uuid uuid.UUID
-	if u != nil {
-		uuid = *u
+	if u == nil {
+		// we ignore non-device-specific requests for now
+		log.Printf("error saving request for device without UUID")
+		return
 	}
-	h.manager.WriteRequest(common.ApiRequest{
+	req := ApiRequest{
 		Timestamp: time.Now(),
-		UUID:      uuid,
+		UUID:      *u,
 		ClientIP:  r.RemoteAddr,
 		Forwarded: r.Header.Get("X-Forwarded-For"),
 		Method:    r.Method,
 		URL:       r.URL.String(),
-	})
+	}
+	b, err := json.Marshal(req)
+	if err != nil {
+		log.Printf("error saving request structure: %v", err)
+		return
+	}
+
+	h.manager.WriteRequest(*u, b)
 }
 
 func (h *apiHandler) register(w http.ResponseWriter, r *http.Request) {
@@ -97,9 +120,15 @@ func (h *apiHandler) register(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}
-	// we do not keep the uuid or send it back; perhaps a future version of the API will support it
-	_, err = h.manager.DeviceRegister(deviceCert, onboardCert, serial)
+	// generate a new uuid
+	unew, err := uuid.NewV4()
 	if err != nil {
+		log.Printf("error generating a new device UUID: %v", err)
+		http.Error(w, fmt.Sprintf("error generating a new device UUID: %v", err), http.StatusBadRequest)
+		return
+	}
+	// we do not keep the uuid or send it back; perhaps a future version of the API will support it
+	if err := h.manager.DeviceRegister(unew, deviceCert, onboardCert, serial, common.CreateBaseConfig(unew)); err != nil {
 		log.Printf("error registering new device: %v", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
@@ -142,23 +171,40 @@ func (h *apiHandler) configPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	h.recordClient(u, r)
-	config, err := h.manager.GetConfigResponse(*u)
+	conf, err := h.manager.GetConfig(*u)
 	if err != nil {
 		log.Printf("error getting device config: %v", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
+
+	// convert config into a protobuf
+	var msg config.EdgeDevConfig
+	if err := protojson.Unmarshal(conf, &msg); err != nil {
+		log.Printf("error reading device config: %v", err)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	response := &config.ConfigResponse{}
+
+	hash := sha256.New()
+	common.ComputeConfigElementSha(hash, &msg)
+	configHash := hash.Sum(nil)
+
+	response.Config = &msg
+	response.ConfigHash = base64.URLEncoding.EncodeToString(configHash)
+
 	configRequest, err := getClientConfigRequest(r)
 	if err != nil {
 		log.Printf("error getting config request: %v", err)
 	} else {
 		//compare received config hash with current
-		if strings.Compare(configRequest.ConfigHash, config.ConfigHash) == 0 {
+		if strings.Compare(configRequest.ConfigHash, response.ConfigHash) == 0 {
 			w.WriteHeader(http.StatusNotModified)
 			return
 		}
 	}
-	out, err := proto.Marshal(config)
+	out, err := proto.Marshal(response)
 	if err != nil {
 		log.Printf("error converting config to byte message: %v", err)
 	}
@@ -188,13 +234,9 @@ func (h *apiHandler) config(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
-	out, err := proto.Marshal(config)
-	if err != nil {
-		log.Printf("error converting config to byte message: %v", err)
-	}
 	w.Header().Add(contentType, mimeProto)
 	w.WriteHeader(http.StatusOK)
-	w.Write(out)
+	w.Write(config)
 }
 
 func (h *apiHandler) info(w http.ResponseWriter, r *http.Request) {
@@ -220,10 +262,10 @@ func (h *apiHandler) info(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	select {
-	case h.infoChannel <- msg:
+	case h.infoChannel <- b:
 	default:
 	}
-	err = h.manager.WriteInfo(msg)
+	err = h.manager.WriteInfo(*u, b)
 	if err != nil {
 		log.Printf("Failed to write info message: %v", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -255,7 +297,7 @@ func (h *apiHandler) metrics(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}
-	err = h.manager.WriteMetrics(msg)
+	err = h.manager.WriteMetrics(*u, b)
 	if err != nil {
 		log.Printf("Failed to write metrics message: %v", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -288,10 +330,28 @@ func (h *apiHandler) logs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	select {
-	case h.logChannel <- msg:
+	case h.logChannel <- b:
 	default:
 	}
-	err = h.manager.WriteLogs(msg)
+	eveVersion := msg.GetEveVersion()
+	image := msg.GetImage()
+	var buf bytes.Buffer
+	for _, entry := range msg.GetLog() {
+		entry := &common.FullLogEntry{
+			LogEntry:   entry,
+			Image:      image,
+			EveVersion: eveVersion,
+		}
+		// convert the message to bytes
+		entryBytes, err := entry.Json()
+		if err != nil {
+			log.Printf("failed to marshal protobuf message into json: %v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		}
+		buf.Write(entryBytes)
+	}
+
+	err = h.manager.WriteLogs(*u, buf.Bytes())
 	if err != nil {
 		log.Printf("Failed to write logbundle message: %v", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -334,10 +394,10 @@ func (h *apiHandler) appLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	select {
-	case h.logChannel <- msg:
+	case h.logChannel <- b:
 	default:
 	}
-	err = h.manager.WriteAppInstanceLogs(uid, *u, msg)
+	err = h.manager.WriteAppInstanceLogs(uid, *u, b)
 	if err != nil {
 		log.Printf("Failed to write appinstancelogbundle message: %v", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -345,4 +405,20 @@ func (h *apiHandler) appLogs(w http.ResponseWriter, r *http.Request) {
 	}
 	// send back a 201
 	w.WriteHeader(http.StatusCreated)
+}
+
+// retrieve the config request
+func getClientConfigRequest(r *http.Request) (*config.ConfigRequest, error) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("Body read failed: %v", err)
+		return nil, err
+	}
+	configRequest := &config.ConfigRequest{}
+	err = proto.Unmarshal(body, configRequest)
+	if err != nil {
+		log.Printf("Unmarshalling failed: %v", err)
+		return nil, err
+	}
+	return configRequest, nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -7,13 +7,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
-
-	"github.com/golang/protobuf/proto"
-	"github.com/lf-edge/eve/api/go/config"
 
 	"github.com/gorilla/mux"
 	"github.com/lf-edge/adam/pkg/driver"
@@ -52,8 +48,8 @@ func (s *Server) Start() {
 	router.NotFoundHandler = http.HandlerFunc(notFound)
 
 	// to pass logs and info around
-	logChannel := make(chan proto.Message)
-	infoChannel := make(chan proto.Message)
+	logChannel := make(chan []byte)
+	infoChannel := make(chan []byte)
 
 	// edgedevice endpoint - fully compliant with EVE open API
 	api := &apiHandler{
@@ -149,22 +145,6 @@ func logRequest(next http.Handler) http.Handler {
 // retrieve the client cert
 func getClientCert(r *http.Request) *x509.Certificate {
 	return r.TLS.PeerCertificates[0]
-}
-
-// retrieve the config request
-func getClientConfigRequest(r *http.Request) (*config.ConfigRequest, error) {
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		log.Printf("Body read failed: %v", err)
-		return nil, err
-	}
-	configRequest := &config.ConfigRequest{}
-	err = proto.Unmarshal(body, configRequest)
-	if err != nil {
-		log.Printf("Unmarshalling failed: %v", err)
-		return nil, err
-	}
-	return configRequest, nil
 }
 
 func notFound(w http.ResponseWriter, r *http.Request) {

--- a/pkg/util/protobuf.go
+++ b/pkg/util/protobuf.go
@@ -1,19 +1,11 @@
 package util
 
 import (
-	"bytes"
-	"fmt"
-
-	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 // ProtobufToBytes convert a protobuf to bytes
 func ProtobufToBytes(msg proto.Message) ([]byte, error) {
-	buf := bytes.NewBuffer([]byte{})
-	mler := jsonpb.Marshaler{}
-	if err := mler.Marshal(buf, msg); err != nil {
-		return nil, fmt.Errorf("failed to marshal protobuf message into json: %v", err)
-	}
-	return buf.Bytes(), nil
+	return protojson.Marshal(msg)
 }


### PR DESCRIPTION
This is a pretty big PR. Unfortunately, too many pieces were interwoven to avoid it. Fortunately, this makes future ones easier.

The heart of this is removing any protobuf-specific knowledge from any of the backends. Backends store `string` or `[]byte` and that is it.

Any processing of protobufs to/from bytes (mostly json) happens entirely in `apiHandler` or `adminHandler`. 

The net result of this is:

* much easier to handle and reason about backend drivers, let alone add more
* removal of a lot of duplicated code inside drivers
* removal of some now-unnecessary `DeviceManager interface` parts
* moving many of the safety checks out of the drivers and into the unified wrapper
* many of the tests become simplified

On the way, I removed the long-deprecated jsonpb processor library in favour of the official protojson library.

Finally, I eliminated the `LogBundle` structure, which really just wrapped lots of `LogEntry` plus added some metadata, in favour of extended json with the two key fields from `LogBundle` - eve version and image - added on.

I also managed to remove _much_, but not _all_, of the explicit protobuf dependencies from the `driver_*_test.go` files. There still are a few. I will get to them in a future PR.

This is some real, if necessary, surgery. While it looks good, my testing pales compared to what the eden-maintaining team puts these things through. It would be much appreciated if someone from that team could build this and put it through its paces.

cc @rvs @giggsoff 