### PR TITLE
check URL endpoint in file manager; put test artifacts in tmpdir

### DIFF
--- a/pkg/driver/device_managers_test.go
+++ b/pkg/driver/device_managers_test.go
@@ -1,6 +1,9 @@
 package driver_test
 
 import (
+	"io/ioutil"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/lf-edge/adam/pkg/driver"
@@ -23,7 +26,13 @@ func TestURLs(t *testing.T) {
 		})
 	}
 
-	for _, url := range []string{"", "foo/bar/baz", "http://google.com", "/etc/hosts", "redis://a.b:1/2/3/4"} {
+	// create a temporary working dir, because the file driver actually creates the directories
+	tmpdir, err := ioutil.TempDir("", "adam-driver-test")
+	if err != nil {
+		t.Fatalf("could not create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tmpdir)
+	for _, url := range []string{"", path.Join(tmpdir, "foo/bar/baz"), "http://google.com", "/etc/hosts", "redis://a.b:1/2/3/4"} {
 		t.Run("non-redis-url", func(t *testing.T) {
 			var mgr driver.DeviceManager
 			for _, mgr = range driver.GetDeviceManagers() {

--- a/pkg/driver/file/device_manager_file.go
+++ b/pkg/driver/file/device_manager_file.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -182,6 +183,17 @@ func (d *DeviceManager) MaxAppLogsSize() int {
 
 // Init check if a URL is valid and initialize
 func (d *DeviceManager) Init(s string, sizes common.MaxSizes) (bool, error) {
+	// parse the URL
+	// we accept the following:
+	// - scheme = file
+	// - invalid URL (everything is path)
+	URL, err := url.Parse(s)
+	if err != nil {
+		return false, err
+	}
+	if URL.Scheme != "file" && URL.Scheme != "" {
+		return false, nil
+	}
 	fi, err := os.Stat(s)
 	if err == nil && !fi.IsDir() {
 		return false, fmt.Errorf("database path %s exists and is not a directory", s)


### PR DESCRIPTION
Two things:

* checks the URL endpoint in file manager. Before, it was just taking the string as is, which creates some really strange behaviours, such as creating a directory named `redis:`. Now, it checks the URL. It was supposed to do this originally.
* For the one place in tests where it actually creates a directory, do it in a tempdir with an automatic cleanup.
