### PR TITLE
Allowing to trigger publish workflow manually

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,10 +3,14 @@ name: Publish
 
 on:
   push:
-    branches: main
+    branches:
+      - "master"
+
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 env:
-  IMAGE_NAME: lfedge/adam
+  IMAGE_NAME: "lfedge/adam"
 
 jobs:
   publish:


### PR DESCRIPTION
Signed-off-by: Roman Shaposhnik <rvs@zededa.com>