### PR TITLE
report gofmt output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,6 @@ jobs:
       - name: unit tests
         run: go test ./...
       - name: fmt
-        run: test -z "$(gofmt -l -e -s $(find . -name '*.go'))"
+        run: test -z "$( gofmt -l -e -s $(find . -name '*.go') | tee /dev/stderr )"
       - name: build
         run: go build .


### PR DESCRIPTION
The `fmt` check was checking if formatting is good, but not reporting the output to logs. Of course, someone always can rerun it locally - which is what we did beforehand - but it really should report the error on the logs, rather than confusing someone.