### PR TITLE
sync api version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-redis/redis v6.15.7+incompatible
 	github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0
 	github.com/gorilla/mux v1.7.2
-	github.com/lf-edge/eve/api/go v0.0.0-20201223041948-f66d1d3f800d
+	github.com/lf-edge/eve/api/go v0.0.0-20210127150154-7439b6ee86b4
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.10.0 // indirect
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/lf-edge/eve/api/go v0.0.0-20201031014148-3a9bcf5d26a7 h1:IWo92XYyZ5W8
 github.com/lf-edge/eve/api/go v0.0.0-20201031014148-3a9bcf5d26a7/go.mod h1:DuAv0PyTTzmd3n25iHJ/Hx2SrbON4hf3I0oXfnUH4d8=
 github.com/lf-edge/eve/api/go v0.0.0-20201223041948-f66d1d3f800d h1:BacPq4YVW+GuathmMnZk92Bf8LNwchrQXw5LJvFnNc4=
 github.com/lf-edge/eve/api/go v0.0.0-20201223041948-f66d1d3f800d/go.mod h1:DuAv0PyTTzmd3n25iHJ/Hx2SrbON4hf3I0oXfnUH4d8=
+github.com/lf-edge/eve/api/go v0.0.0-20210127150154-7439b6ee86b4 h1:DtjuBnm9bNra6/NoOyBd6qYFDO8CZHUfjH7NbGR5F9I=
+github.com/lf-edge/eve/api/go v0.0.0-20210127150154-7439b6ee86b4/go.mod h1:DuAv0PyTTzmd3n25iHJ/Hx2SrbON4hf3I0oXfnUH4d8=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=


### PR DESCRIPTION
We need to sync version of `github.com/lf-edge/eve/api/go`

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>