### PR TITLE
removal of fixed architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN go mod download
 COPY . /adam/src
 
 ARG GOOS=linux
-ARG GOARCH=amd64
+# ARG GOARCH=amd64
 
 RUN go build -o /adam/bin/adam main.go
 


### PR DESCRIPTION
We need to remove line with fixed architecture now. We do not use build-args, but we have GH Action to build with several architectures (amd64 and arm64).

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>