### PR TITLE
redis timeout and retries expand and more verbosity in logs

### DIFF
--- a/pkg/server/apiHandler.go
+++ b/pkg/server/apiHandler.go
@@ -123,7 +123,7 @@ func (h *apiHandler) configPost(w http.ResponseWriter, r *http.Request) {
 	}
 	data, code, err := configProcess(configRequest, cfg)
 	if err != nil {
-		log.Println(err)
+		log.Printf("error configProcess: %v", err)
 		http.Error(w, http.StatusText(code), code)
 		return
 	}

--- a/pkg/x509/generate.go
+++ b/pkg/x509/generate.go
@@ -33,6 +33,9 @@ func Generate(cn, hosts string) ([]byte, *rsa.PrivateKey, error) {
 
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate serial number: %v", err)
+	}
 
 	notBefore := time.Now()
 	notAfter := notBefore.Add(oneYear)


### PR DESCRIPTION
In order to stabilize long-running scenarios #95 we can expand timeouts and add retry to our redis client

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>