### PR TITLE
fix api v2 endpoints to use certificates from AuthContainer

### DIFF
--- a/pkg/driver/device_manager.go
+++ b/pkg/driver/device_manager.go
@@ -55,6 +55,8 @@ type DeviceManager interface {
 	OnboardRegister(*x509.Certificate, []string) error
 	// DeviceCheckCert check if a certificate is valid to use for a device
 	DeviceCheckCert(*x509.Certificate) (*uuid.UUID, error)
+	// DeviceCheckCertHash check if a certificate hash is valid to use for a device
+	DeviceCheckCertHash([]byte) (*uuid.UUID, error)
 	// DeviceRemove remove a device
 	DeviceRemove(*uuid.UUID) error
 	// DeviceClear remove all devices

--- a/pkg/driver/file/device_manager_file_test.go
+++ b/pkg/driver/file/device_manager_file_test.go
@@ -342,8 +342,8 @@ func TestDeviceManager(t *testing.T) {
 		}
 	})
 
-	// DeviceCheckCert for file is identical to Memory, since it just uses the cache, so no testing here
-	t.Run("TestDeviceCheckCert", func(t *testing.T) {
+	// DeviceCheckCert and DeviceCheckCertHash for file is identical to Memory, since it just uses the cache, so no testing here
+	t.Run("TestDeviceCheckCertAndHash", func(t *testing.T) {
 	})
 
 	t.Run("TestDeviceRemove", func(t *testing.T) {

--- a/pkg/driver/memory/device_manager_memory.go
+++ b/pkg/driver/memory/device_manager_memory.go
@@ -4,6 +4,8 @@
 package memory
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"crypto/x509"
 	"fmt"
 	"io"
@@ -196,6 +198,20 @@ func (d *DeviceManager) DeviceCheckCert(cert *x509.Certificate) (*uuid.UUID, err
 		return &u, nil
 	}
 	return nil, nil
+}
+
+// DeviceCheckCertHash see if a particular certificate hash is a valid registered device certificate
+func (d *DeviceManager) DeviceCheckCertHash(hash []byte) (*uuid.UUID, error) {
+	if hash == nil {
+		return nil, fmt.Errorf("invalid empty hash")
+	}
+	for k, u := range d.deviceCerts {
+		s := sha256.Sum256([]byte(k))
+		if bytes.Equal(hash, s[:]) {
+			return &u, nil
+		}
+	}
+	return nil, fmt.Errorf("cert hash not found")
 }
 
 // DeviceRemove remove a device

--- a/pkg/x509/io.go
+++ b/pkg/x509/io.go
@@ -71,6 +71,9 @@ func ParseCert(b []byte) (*x509.Certificate, error) {
 		cert    *x509.Certificate
 	)
 	certPem, _ = pem.Decode(b)
+	if certPem == nil {
+		return nil, fmt.Errorf("unable to decode pem")
+	}
 	cert, err = x509.ParseCertificate(certPem.Bytes)
 	if err != nil {
 		return nil, fmt.Errorf("unable to convert data to certificate: %v", err)


### PR DESCRIPTION
For now Adam checks certificates comes from TLS layer against saved in the database . But as described in https://github.com/lf-edge/eve/blob/master/api/APIv2.md#authentication we must move from checking TLS certificates to checking of AuthContainer`s certificates. After https://github.com/lf-edge/eve/pull/2333 we must use AuthContainer to be in sync with official controller and to not have complains in logs.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>