### PR TITLE
storage keys management

### DIFF
--- a/pkg/driver/common/common.go
+++ b/pkg/driver/common/common.go
@@ -50,6 +50,7 @@ type DeviceStorage struct {
 	CurrentLog  int
 	Config      []byte
 	ATtestCerts []byte
+	StorageKeys []byte
 	Serial      string
 	Onboard     *x509.Certificate
 }

--- a/pkg/driver/device_manager.go
+++ b/pkg/driver/device_manager.go
@@ -69,6 +69,8 @@ type DeviceManager interface {
 	DeviceRegister(uuid.UUID, *x509.Certificate, *x509.Certificate, string, []byte) error
 	// WriteCerts write an attestation certs information
 	WriteCerts(uuid.UUID, []byte) error
+	// WriteStorageKeys write storage keys information
+	WriteStorageKeys(uuid.UUID, []byte) error
 	// WriteInfo write an information message
 	WriteInfo(uuid.UUID, []byte) error
 	// WriteLogs write log messages
@@ -95,4 +97,6 @@ type DeviceManager interface {
 	GetRequestsReader(u uuid.UUID) (io.Reader, error)
 	// GetCerts retrieve the attest certs for a particular device
 	GetCerts(uid uuid.UUID) ([]byte, error)
+	// GetStorageKeys retrieve storage keys for a particular device
+	GetStorageKeys(uid uuid.UUID) ([]byte, error)
 }

--- a/pkg/driver/memory/device_manager_memory.go
+++ b/pkg/driver/memory/device_manager_memory.go
@@ -429,6 +429,30 @@ func (d *DeviceManager) GetCerts(u uuid.UUID) ([]byte, error) {
 	return dev.ATtestCerts, nil
 }
 
+// WriteStorageKeys write storage keys information
+func (d *DeviceManager) WriteStorageKeys(u uuid.UUID, b []byte) error {
+	// look up the device by uuid
+	dev, ok := d.devices[u]
+	if !ok {
+		return fmt.Errorf("unregistered device UUID %s", u.String())
+	}
+	if len(b) < 1 {
+		return fmt.Errorf("empty configuration")
+	}
+	dev.StorageKeys = b
+	return nil
+}
+
+// GetStorageKeys retrieve storage keys for a particular device
+func (d *DeviceManager) GetStorageKeys(u uuid.UUID) ([]byte, error) {
+	// look up the device by uuid
+	dev, ok := d.devices[u]
+	if !ok {
+		return nil, fmt.Errorf("unregistered device UUID %s", u.String())
+	}
+	return dev.StorageKeys, nil
+}
+
 // GetConfig retrieve the config for a particular device
 func (d *DeviceManager) GetConfig(u uuid.UUID) ([]byte, error) {
 	// look up the device by uuid


### PR DESCRIPTION
Implementation of ZAttestReqType_Z_ATTEST_REQ_TYPE_STORE_KEYS request and adding storage keys to quote response.
Those changes required for TPM-enabled EVE to properly work with encrypted vault.