### PR TITLE
Introduce proto-format flag to store data in proto

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -45,6 +45,7 @@ var (
 	maxFlowMessageSize int
 	maxAppLogsSize     int
 	autoCert           bool
+	protoFormat        bool
 	localWebFiles      string
 	deviceManagers     = driver.GetDeviceManagers()
 )
@@ -237,6 +238,7 @@ var serverCmd = &cobra.Command{
 			DeviceManager:   mgr,
 			CertRefresh:     certRefresh,
 			WebDir:          localWebFiles,
+			ProtoFormat:     protoFormat,
 		}
 		s.Start()
 	},
@@ -279,4 +281,5 @@ func serverInit() {
 	serverCmd.Flags().IntVar(&maxFlowMessageSize, "max-flow-message-size", 0, fmt.Sprintf("the maximum size of the FlowMessage logs before rotating. A setting of 0 means to use the default for the particular driver. Those are: %v", defaultFlowMessageSizes))
 	serverCmd.Flags().IntVar(&maxAppLogsSize, "max-app-logs-size", 0, fmt.Sprintf("the maximum size of the app logs before rotating. A setting of 0 means to use the default for the particular driver. Those are: %v", defaultAppLogsSizes))
 	serverCmd.Flags().StringVar(&localWebFiles, "web-dir", "", "path to static files on the local filesystem for the web server; if empty, will use those embedded in the Adam binary")
+	serverCmd.Flags().BoolVar(&protoFormat, "proto-format", false, "Use proto format to store data in managers, it reduces readability, but help us to not update api package on every change")
 }

--- a/pkg/driver/device_manager.go
+++ b/pkg/driver/device_manager.go
@@ -88,7 +88,8 @@ type DeviceManager interface {
 	// SetGlobalOptions stores global options
 	SetGlobalOptions([]byte) error
 	// GetConfig get the config for a given uuid
-	GetConfig(uuid.UUID) ([]byte, error)
+	// if not found will use handler to populate
+	GetConfig(uuid.UUID, common.CreateBaseConfigHandler) ([]byte, error)
 	// SetConfig set the config for a given uuid
 	SetConfig(uuid.UUID, []byte) error
 	// GetUUID get the UuidResponse for a given uuid

--- a/pkg/driver/file/device_manager_file.go
+++ b/pkg/driver/file/device_manager_file.go
@@ -845,14 +845,14 @@ func (d *DeviceManager) GetStorageKeys(u uuid.UUID) ([]byte, error) {
 }
 
 // GetConfig retrieve the config for a particular device
-func (d *DeviceManager) GetConfig(u uuid.UUID) ([]byte, error) {
+func (d *DeviceManager) GetConfig(u uuid.UUID, handler common.CreateBaseConfigHandler) ([]byte, error) {
 	// read the config from disk
 	fullConfigPath := path.Join(d.getDevicePath(u), deviceConfigFilename)
 	b, err := ioutil.ReadFile(fullConfigPath)
 	switch {
 	case err != nil && os.IsNotExist(err):
 		// create the base file if it does not exist
-		b = common.CreateBaseConfig(u)
+		b = handler(u)
 		err = d.writeJSONFile(u, "", deviceConfigFilename, b)
 		if err != nil {
 			return nil, fmt.Errorf("error saving device config to %s: %v", deviceConfigFilename, err)

--- a/pkg/driver/file/device_manager_file_test.go
+++ b/pkg/driver/file/device_manager_file_test.go
@@ -659,7 +659,7 @@ func TestDeviceManager(t *testing.T) {
 				t.Fatalf("error generating a new device UUID: %v", err)
 			}
 
-			err = d.DeviceRegister(unew, deviceCert, onboard, serial, common.CreateBaseConfig(unew))
+			err = d.DeviceRegister(unew, deviceCert, onboard, serial, common.CreateBaseConfig(unew, false))
 			switch {
 			case (err != nil && tt.err == nil) || (err == nil && tt.err != nil) || (err != nil && tt.err != nil && !strings.HasPrefix(err.Error(), tt.err.Error())):
 				t.Errorf("%d: mismatched errors, actual %v expected %v", i, err, tt.err)

--- a/pkg/driver/memory/device_manager_memory.go
+++ b/pkg/driver/memory/device_manager_memory.go
@@ -455,7 +455,7 @@ func (d *DeviceManager) GetStorageKeys(u uuid.UUID) ([]byte, error) {
 }
 
 // GetConfig retrieve the config for a particular device
-func (d *DeviceManager) GetConfig(u uuid.UUID) ([]byte, error) {
+func (d *DeviceManager) GetConfig(u uuid.UUID, _ common.CreateBaseConfigHandler) ([]byte, error) {
 	// look up the device by uuid
 	dev, ok := d.devices[u]
 	if !ok {

--- a/pkg/driver/memory/device_manager_memory_test.go
+++ b/pkg/driver/memory/device_manager_memory_test.go
@@ -629,7 +629,7 @@ func TestDeviceManager(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error generating a new device UUID: %v", err)
 			}
-			err = d.DeviceRegister(u, deviceCert, onboard, serial, common.CreateBaseConfig(u))
+			err = d.DeviceRegister(u, deviceCert, onboard, serial, common.CreateBaseConfig(u, false))
 			switch {
 			case (err != nil && tt.err == nil) || (err == nil && tt.err != nil) || (err != nil && tt.err != nil && !strings.HasPrefix(err.Error(), tt.err.Error())):
 				t.Errorf("%d: mismatched errors, actual %v expected %v", i, err, tt.err)

--- a/pkg/driver/redis/device_manager_redis.go
+++ b/pkg/driver/redis/device_manager_redis.go
@@ -710,13 +710,13 @@ func (d *DeviceManager) GetStorageKeys(u uuid.UUID) ([]byte, error) {
 }
 
 // GetConfig retrieve the config for a particular device
-func (d *DeviceManager) GetConfig(u uuid.UUID) ([]byte, error) {
+func (d *DeviceManager) GetConfig(u uuid.UUID, handler common.CreateBaseConfigHandler) ([]byte, error) {
 	// hold our config
 	var b []byte
 	data, err := d.client.HGet(deviceConfigsHash, u.String()).Result()
 	if err != nil {
 		// if config doesn't exist - create an empty one
-		b = common.CreateBaseConfig(u)
+		b = handler(u)
 		if _, err = d.client.HSet(deviceConfigsHash, u.String(), string(b)).Result(); err == nil {
 			_, err = d.client.Save().Result()
 		}

--- a/pkg/driver/redis/device_manager_redis_test.go
+++ b/pkg/driver/redis/device_manager_redis_test.go
@@ -91,20 +91,20 @@ func TestDeviceRedis(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to generate new UUID: %v", err)
 	}
-	err = r.DeviceRegister(UUID2, cert2, certOnboard, "------", common.CreateBaseConfig(UUID2))
+	err = r.DeviceRegister(UUID2, cert2, certOnboard, "------", common.CreateBaseConfig(UUID2, false))
 	assert.Equal(t, nil, err)
 	UUID3, err := uuid.NewV4()
 	if err != nil {
 		t.Fatalf("unable to generate new UUID: %v", err)
 	}
-	err = r.DeviceRegister(UUID3, cert3, certOnboard, "------", common.CreateBaseConfig(UUID3))
+	err = r.DeviceRegister(UUID3, cert3, certOnboard, "------", common.CreateBaseConfig(UUID3, false))
 	assert.Equal(t, nil, err)
 
 	UUID1, err := uuid.NewV4()
 	if err != nil {
 		t.Fatalf("unable to generate new UUID: %v", err)
 	}
-	err = r.DeviceRegister(UUID1, cert, certOnboard, "123456", common.CreateBaseConfig(UUID1))
+	err = r.DeviceRegister(UUID1, cert, certOnboard, "123456", common.CreateBaseConfig(UUID1, false))
 	assert.Equal(t, nil, err)
 	UUID, err := r.DeviceCheckCert(cert)
 	assert.Equal(t, nil, err)
@@ -160,10 +160,10 @@ func TestConfigRedis(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to generate new UUID: %v", err)
 	}
-	err = r.DeviceRegister(UUID, cert, certOnboard, "123456", common.CreateBaseConfig(UUID))
+	err = r.DeviceRegister(UUID, cert, certOnboard, "123456", common.CreateBaseConfig(UUID, false))
 	assert.Equal(t, nil, err)
 
-	conf, err := r.GetConfig(UUID)
+	conf, err := r.GetConfig(UUID, common.GetCreateBaseConfigHandler(false))
 	assert.Equal(t, nil, err)
 	// convert to struct
 	var msg config.EdgeDevConfig
@@ -182,7 +182,7 @@ func TestConfigRedis(t *testing.T) {
 
 	assert.Equal(t, nil, r.SetConfig(UUID, conf))
 
-	conf, err = r.GetConfig(UUID)
+	conf, err = r.GetConfig(UUID, common.GetCreateBaseConfigHandler(false))
 	// convert to struct
 	if err := protojson.Unmarshal(conf, &msg); err != nil {
 		t.Fatalf("error converting device config bytes to struct: %v", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -33,7 +33,8 @@ type Server struct {
 	DeviceManager   driver.DeviceManager
 	CertRefresh     int
 	// WebDir path to webfiles to serve. If empty, use embedded
-	WebDir string
+	WebDir      string
+	ProtoFormat bool
 }
 
 // Start start the server
@@ -94,6 +95,7 @@ func (s *Server) Start() {
 		logChannel:    logChannel,
 		infoChannel:   infoChannel,
 		metricChannel: metricChannel,
+		protoFormat:   s.ProtoFormat,
 	}
 
 	router.HandleFunc("/probe", api.probe).Methods("GET")
@@ -124,6 +126,7 @@ func (s *Server) Start() {
 			signingKeyPath:  s.SigningKeyPath,
 			encryptCertPath: s.EncryptCertPath,
 			encryptKeyPath:  s.EncryptKeyPath,
+			protoFormat:     s.ProtoFormat,
 		}
 
 		edv2 := router.PathPrefix("/api/v2/edgedevice").Subrouter()
@@ -150,6 +153,7 @@ func (s *Server) Start() {
 		manager:     s.DeviceManager,
 		logChannel:  logChannel,
 		infoChannel: infoChannel,
+		protoFormat: s.ProtoFormat,
 	}
 
 	ad := router.PathPrefix("/admin").Subrouter()


### PR DESCRIPTION
We store data in json because of readability. But having this format limit us to the version of api bundled into the binary. With optional moving to proto format we can use the same version of api if it will not include changes in AuthContainer logic and will not introduce global changes in how to handle objects.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>