### PR TITLE
fix deviceAdd to accept json input

### DIFF
--- a/pkg/server/adminHandler.go
+++ b/pkg/server/adminHandler.go
@@ -153,7 +153,7 @@ func (h *adminHandler) onboardClear(w http.ResponseWriter, r *http.Request) {
 func (h *adminHandler) deviceAdd(w http.ResponseWriter, r *http.Request) {
 	// extract certificate and serials from request body
 	contentType := r.Header.Get(contentType)
-	if contentType != mimeTextPlain {
+	if contentType != mimeJSON {
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
deviceAddCmd sends a json encoded POST request to deviceAdd handler, but when json is sent, the handler checks for plain text input and returns a 400 Bad request error.  

This commit fixes the issue and commands like `adam admin device add` now work : 
```
$ adam admin device add --path ~/eve/conf/onboard.cert.pem
$ adam admin device list
10435615-3c36-4e82-91f0-4e4dc65d5560
```