### PR TITLE
Fix broken links to EVE API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Adam
 
-Welcome to Adam! Adam is the reference implementation of an [LF-Edge](https://www.lfedge.org) [API-compliant Controller](https://github.com/lf-edge/eve/blob/master/api/README.md). You can use Adam to drive one or more [EVE](https://www.lfedge.org/projects/eve/) instances from any computer, locally, in the cloud, or in a container.
+Welcome to Adam! Adam is the reference implementation of an [LF-Edge](https://www.lfedge.org) [API-compliant Controller](https://github.com/lf-edge/eve-api/blob/main/README.md). You can use Adam to drive one or more [EVE](https://www.lfedge.org/projects/eve/) instances from any computer, locally, in the cloud, or in a container.
 
-Adam is a reference implementation. Thus, while it has all of the TLS encryption and authentication requirements of [the official API](https://github.com/lf-edge/eve/blob/master/api/README.md), it has not been built or tested to withstand penetration attacks, DDoS, or any other major security requirements, and it has not been built with massive scale in mind. For those, please refer to various vendor cloud controller offerings, such as [Zededa zedcloud](https://www.zededa.com/technology/).
+Adam is a reference implementation. Thus, while it has all of the TLS encryption and authentication requirements of [the official API](https://github.com/lf-edge/eve-api/blob/main/README.md), it has not been built or tested to withstand penetration attacks, DDoS, or any other major security requirements, and it has not been built with massive scale in mind. For those, please refer to various vendor cloud controller offerings, such as [Zededa zedcloud](https://www.zededa.com/technology/).
 
 ## Running Adam
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,6 +1,6 @@
 # Configuration Files
 
-According to [the API](http://github.com/lf-edge/eve/blob/master/api/API.md) and the [EVE implementation](http://github.com/lf-edge/eve), once a device is registered, it will ask for its config with some regularity.
+According to [the API](https://github.com/lf-edge/eve-api/blob/main/APIv2.md) and the [EVE implementation](http://github.com/lf-edge/eve), once a device is registered, it will ask for its config with some regularity.
 
 Adam does _not_ require pre-registration or pre-configuration of devices. You _can_ pre-register devices by installing the device certificate, or you can activate a device by installing an onboarding certificate and the serial number for the device (or a wildcard).
 

--- a/docs/directory-structure.md
+++ b/docs/directory-structure.md
@@ -42,7 +42,7 @@ Each directory in `device/` represents a unique registered device, with the dire
 
 The purpose of each file and directory is as follows:
 
-* `config.json` - configuration of format `config.EdgeDevConfig` from [the API](https://github.com/lf-edge/eve/blob/master/api/API.md), marshalled to json.
+* `config.json` - configuration of format `config.EdgeDevConfig` from [the API](https://github.com/lf-edge/eve-api/blob/main/APIv2.md), marshalled to json.
 * `onboard-certificate.pem` - the onboard certificate used when this device self-registered. If the device was registered directly, this file will not exist.
 * `device-certificate.pem` - the device certificate for this device.
 * `serial.txt` - the serial used when this device self-registered. If the device was registered directly, this file will not exist.


### PR DESCRIPTION
The eve-api was broken out into its own repo last year. There were a few links in the adam docs that were still pointing to their old location, leading to page not found errors. This updates the links to point to their current locations.