### PR TITLE
Don't panic if there is no onboard cert

### DIFF
--- a/pkg/driver/file/device_manager_file.go
+++ b/pkg/driver/file/device_manager_file.go
@@ -1137,6 +1137,9 @@ func (d *DeviceManager) checkValidOnboardSerial(cert *x509.Certificate, serial s
 func (d *DeviceManager) getOnboardSerialDevice(cert *x509.Certificate, serial string) *uuid.UUID {
 	certStr := string(cert.Raw)
 	for uid, dev := range d.devices {
+		if dev.Onboard == nil {
+			continue
+		}
 		dCertStr := string(dev.Onboard.Raw)
 		if dCertStr == certStr && serial == dev.Serial {
 			return &uid


### PR DESCRIPTION
If device is added but not onboarded, dev.Onboard can be nil, so we need to check for that before accessing the cert.