### PR TITLE
GitHub Actions: bump runners ubuntu version to latest available

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
Accoring to [1] Ubuntu 20.04 runners in GitHub will be fully unsuppoerted by 2025-04-01. This commit bumps GitHub-provided runners to latest available Ubuntu 24.04

I am not changing runners to latest because fixed version guarantees stability of packages across workflow runs

[1] - https://github.com/actions/runner-images/issues/11101