### PR TITLE
Support multiple listen IP addresses

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/lf-edge/adam/pkg/driver/common"
 
@@ -35,7 +36,7 @@ var (
 	certCN             string
 	certHosts          string
 	port               string
-	hostIP             string
+	listenIPs          []string
 	certRefresh        int
 	maxLogSize         int
 	maxInfoSize        int
@@ -117,8 +118,14 @@ var serverCmd = &cobra.Command{
 			log.Fatalf("error writing to server file: %v", err)
 		}
 
-		err = os.WriteFile(path.Join(configDir, "hosts"), []byte(hostIP+" "+ca.Subject.CommonName), 0644)
-		if err != nil {
+		var hostsEntries []string
+		for _, ip := range listenIPs {
+			hostsEntries = append(hostsEntries,
+				fmt.Sprintf("%s %s", ip, ca.Subject.CommonName))
+		}
+		hostsContent := strings.Join(hostsEntries, "\n")
+		hostsPath := path.Join(configDir, "hosts")
+		if err := os.WriteFile(hostsPath, []byte(hostsContent), 0644); err != nil {
 			log.Fatalf("error writing hosts file: %v", err)
 		}
 
@@ -171,7 +178,7 @@ var serverCmd = &cobra.Command{
 
 		s := &server.Server{
 			Port:            port,
-			Address:         hostIP,
+			ListenIPs:       listenIPs,
 			CertPath:        serverCert,
 			KeyPath:         serverKey,
 			SigningCertPath: signingCert,
@@ -203,7 +210,8 @@ func serverInit() {
 		defaultAppLogsSizes = append(defaultAppLogsSizes, fmt.Sprintf("%s:%d", m.Name(), m.MaxAppLogsSize()))
 	}
 	serverCmd.Flags().StringVar(&port, "port", defaultPort, "port on which to listen")
-	serverCmd.Flags().StringVar(&hostIP, "ip", defaultIP, "IP address on which to listen")
+	serverCmd.Flags().StringSliceVar(&listenIPs, "ip", []string{defaultIP},
+		"IP addresses on which to listen (can be specified multiple times)")
 	serverCmd.Flags().StringVar(&serverCert, "server-cert", path.Join(defaultDatabaseURL, serverCertFilename), "path to server certificate")
 	serverCmd.Flags().StringVar(&serverKey, "server-key", path.Join(defaultDatabaseURL, serverKeyFilename), "path to server key")
 	serverCmd.Flags().StringVar(&signingCert, "signing-cert", path.Join(defaultDatabaseURL, signingCertFilename), "path to signing certificate")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -9,13 +9,14 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"fmt"
 	"io"
 	"io/fs"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -27,7 +28,7 @@ import (
 // Server an adam server
 type Server struct {
 	Port            string
-	Address         string
+	ListenIPs       []string
 	CertPath        string
 	KeyPath         string
 	SigningCertPath string
@@ -238,23 +239,33 @@ func (s *Server) Start() {
 
 	server := &http.Server{
 		Handler:   router,
-		Addr:      fmt.Sprintf("%s:%s", s.Address, s.Port),
 		TLSConfig: tlsConfig,
 	}
 	log.Println("Starting adam:")
-	log.Printf("\tURL: https://%s:%s\n", s.Address, s.Port)
+	for _, ip := range s.ListenIPs {
+		log.Printf("\tURL: https://%s\n", net.JoinHostPort(ip, s.Port))
+	}
 	log.Printf("\tstorage: %s\n", s.DeviceManager.Name())
 	log.Printf("\tdatabase: %s\n", s.DeviceManager.Database())
 	log.Printf("\tserver cert: %s\n", s.CertPath)
 	log.Printf("\tserver key: %s\n", s.KeyPath)
-	done := make(chan bool)
-	go func() {
-		err := server.ListenAndServeTLS(s.CertPath, s.KeyPath)
-		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Fatalf("Listen and serve: %v", err)
+
+	var wg sync.WaitGroup
+	for _, listenIP := range s.ListenIPs {
+		addr := net.JoinHostPort(listenIP, s.Port)
+		listener, err := net.Listen("tcp", addr)
+		if err != nil {
+			log.Fatalf("Failed to listen on address %s: %v", addr, err)
 		}
-		done <- true
-	}()
+		wg.Add(1)
+		go func(listener net.Listener) {
+			defer wg.Done()
+			err := server.ServeTLS(listener, s.CertPath, s.KeyPath)
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				log.Fatalf("HTTPS server error: %v", err)
+			}
+		}(listener)
+	}
 	<-irqSig
 	log.Printf("server shutdown starting")
 
@@ -267,7 +278,7 @@ func (s *Server) Start() {
 	if err != nil {
 		log.Printf("Shutdown request error: %v", err)
 	}
-	<-done
+	wg.Wait()
 	log.Printf("server shutdown done")
 }
 


### PR DESCRIPTION
Allow Adam to bind to multiple IP addresses simultaneously by accepting
repeated `--ip` flags (`--ip 192.0.2.1 --ip ::1`) or a comma-separated list
(`--ip 192.0.2.1,::1`). The primary motivation is dual-stack testing:
binding to both an IPv4 and an IPv6 address lets developers verify
EVE-to-controller connectivity over both IP versions without running
separate Adam instances.
    
The change is backward compatible: existing deployments that pass a
single `--ip` value continue to work without modification.
