### PR TITLE
Do not create base device config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    services:
+      # Redis is required so that the Redis driver unit tests are not skipped.
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/pkg/driver/common/common.go
+++ b/pkg/driver/common/common.go
@@ -5,7 +5,6 @@ package common
 
 import (
 	"crypto/x509"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -13,11 +12,9 @@ import (
 
 	"github.com/lf-edge/eve-api/go/attest"
 	"github.com/lf-edge/eve-api/go/certs"
-	"github.com/lf-edge/eve-api/go/config"
 	"github.com/lf-edge/eve-api/go/logs"
 	uuid "github.com/satori/go.uuid"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -180,30 +177,4 @@ func (d *DeviceStorage) AddFlowRecord(b []byte) error {
 	}
 	_, err := d.FlowMessage.Write(b)
 	return err
-}
-
-func CreateBaseConfig(u uuid.UUID) []byte {
-	conf := &config.EdgeDevConfig{
-		Id: &config.UUIDandVersion{
-			Uuid:    u.String(),
-			Version: "4",
-		},
-	}
-	// we ignore the error because it is tightly controlled
-	// we probably should handle it, but then we have to do it with everything downstream
-	// eventually
-	b, _ := proto.Marshal(conf)
-	return b
-}
-
-func CreateBaseDeviceOptions(_ uuid.UUID) []byte {
-	conf := &DeviceOptions{}
-	b, _ := json.Marshal(conf)
-	return b
-}
-
-func CreateBaseGlobalOptions() []byte {
-	conf := &GlobalOptions{}
-	b, _ := json.Marshal(conf)
-	return b
 }

--- a/pkg/driver/device_manager.go
+++ b/pkg/driver/device_manager.go
@@ -64,7 +64,7 @@ type DeviceManager interface {
 	// DeviceList list all of the known UUIDs for devices
 	DeviceList() ([]*uuid.UUID, error)
 	// DeviceRegister register a new device certificate, including the onboarding certificate used to register it and its serial
-	DeviceRegister(uuid.UUID, *x509.Certificate, *x509.Certificate, string, []byte) error
+	DeviceRegister(uuid.UUID, *x509.Certificate, *x509.Certificate, string) error
 	// WriteCerts write an attestation certs information
 	WriteCerts(uuid.UUID, []byte) error
 	// WriteStorageKeys write storage keys information

--- a/pkg/driver/file/device_manager_file.go
+++ b/pkg/driver/file/device_manager_file.go
@@ -583,7 +583,7 @@ func (d *DeviceManager) initDevice(u uuid.UUID) error {
 }
 
 // DeviceRegister register a new device cert
-func (d *DeviceManager) DeviceRegister(unew uuid.UUID, cert, onboard *x509.Certificate, serial string, conf []byte) error {
+func (d *DeviceManager) DeviceRegister(unew uuid.UUID, cert, onboard *x509.Certificate, serial string) error {
 	// check if it already exists - this also checks for nil cert
 	u, err := d.DeviceCheckCert(cert)
 	if err != nil {
@@ -624,11 +624,6 @@ func (d *DeviceManager) DeviceRegister(unew uuid.UUID, cert, onboard *x509.Certi
 		if err != nil {
 			return fmt.Errorf("error saving device serial to %s: %v", serialPath, err)
 		}
-	}
-	// save the base configuration
-	err = d.writeJSONFile(unew, "", deviceConfigFilename, conf)
-	if err != nil {
-		return fmt.Errorf("error saving device config to %s: %v", deviceConfigFilename, err)
 	}
 
 	// save new one to cache - just the serial and onboard; the rest is on disk
@@ -854,12 +849,10 @@ func (d *DeviceManager) GetConfig(u uuid.UUID) ([]byte, error) {
 	b, err := os.ReadFile(fullConfigPath)
 	switch {
 	case err != nil && os.IsNotExist(err):
-		// create the base file if it does not exist
-		b = common.CreateBaseConfig(u)
-		err = d.writeJSONFile(u, "", deviceConfigFilename, b)
-		if err != nil {
-			return nil, fmt.Errorf("error saving device config to %s: %v", deviceConfigFilename, err)
+		err = &common.NotFoundError{
+			Err: fmt.Sprintf("config not found for device UUID %s", u),
 		}
+		return nil, err
 	case err != nil:
 		return nil, fmt.Errorf("could not read config from %s: %v", fullConfigPath, err)
 	}
@@ -1270,17 +1263,13 @@ func (d *DeviceManager) GetDeviceOptions(u uuid.UUID) ([]byte, error) {
 	fullOptionsPath := path.Join(d.getDevicePath(u), deviceOptionsFilename)
 	b, err := os.ReadFile(fullOptionsPath)
 	if err != nil {
-		// if error another than not exists than return
-		if !os.IsNotExist(err) {
-			return nil, fmt.Errorf("could not read options from %s: %v", fullOptionsPath, err)
+		if os.IsNotExist(err) {
+			err = &common.NotFoundError{
+				Err: fmt.Sprintf("options not found for device UUID: %s", u),
+			}
+			return nil, err
 		}
-		// if is not exists, try to create default options
-		cfg := common.CreateBaseDeviceOptions(u)
-		err = d.SetDeviceOptions(u, cfg)
-		if err != nil {
-			return nil, fmt.Errorf("cannot set default options for %s: %s", u, err)
-		}
-		return cfg, nil
+		return nil, fmt.Errorf("could not read options from %s: %v", fullOptionsPath, err)
 	}
 	return b, nil
 }
@@ -1290,5 +1279,16 @@ func (d *DeviceManager) SetGlobalOptions(b []byte) error {
 }
 
 func (d *DeviceManager) GetGlobalOptions() ([]byte, error) {
-	return os.ReadFile(filepath.Join(d.databasePath, globalOptionsFilename))
+	fullOptionsPath := filepath.Join(d.databasePath, globalOptionsFilename)
+	b, err := os.ReadFile(fullOptionsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			err = &common.NotFoundError{
+				Err: "global options not found",
+			}
+			return nil, err
+		}
+		return nil, fmt.Errorf("could not read options from %s: %v", fullOptionsPath, err)
+	}
+	return b, nil
 }

--- a/pkg/driver/file/device_manager_file_test.go
+++ b/pkg/driver/file/device_manager_file_test.go
@@ -660,7 +660,7 @@ func TestDeviceManager(t *testing.T) {
 				t.Fatalf("error generating a new device UUID: %v", err)
 			}
 
-			err = d.DeviceRegister(unew, deviceCert, onboard, serial, common.CreateBaseConfig(unew))
+			err = d.DeviceRegister(unew, deviceCert, onboard, serial)
 			switch {
 			case (err != nil && tt.err == nil) || (err == nil && tt.err != nil) || (err != nil && tt.err != nil && !strings.HasPrefix(err.Error(), tt.err.Error())):
 				t.Errorf("%d: mismatched errors, actual %v expected %v", i, err, tt.err)

--- a/pkg/driver/memory/device_manager_memory.go
+++ b/pkg/driver/memory/device_manager_memory.go
@@ -296,7 +296,7 @@ func (d *DeviceManager) DeviceList() ([]*uuid.UUID, error) {
 }
 
 // DeviceRegister register a new device cert
-func (d *DeviceManager) DeviceRegister(unew uuid.UUID, cert, onboard *x509.Certificate, serial string, conf []byte) error {
+func (d *DeviceManager) DeviceRegister(unew uuid.UUID, cert, onboard *x509.Certificate, serial string) error {
 	// first check if it already exists - this also checks for nil cert
 	if cert == nil {
 		return fmt.Errorf("invalid nil certificate")
@@ -315,7 +315,6 @@ func (d *DeviceManager) DeviceRegister(unew uuid.UUID, cert, onboard *x509.Certi
 	d.devices[unew] = common.DeviceStorage{
 		Onboard: onboard,
 		Serial:  serial,
-		Config:  conf,
 		Logs: &ByteSlice{
 			maxSize: d.maxLogSize,
 		},
@@ -511,6 +510,12 @@ func (d *DeviceManager) GetConfig(u uuid.UUID) ([]byte, error) {
 	if !ok {
 		return nil, fmt.Errorf("unregistered device UUID %s", u.String())
 	}
+	if dev.Config == nil {
+		err := &common.NotFoundError{
+			Err: fmt.Sprintf("config not found for device UUID %s", u),
+		}
+		return nil, err
+	}
 	return dev.Config, nil
 }
 
@@ -650,8 +655,10 @@ func (d *DeviceManager) GetDeviceOptions(u uuid.UUID) ([]byte, error) {
 		return nil, fmt.Errorf("no device UUID %s", u)
 	}
 	if dev.Options == nil {
-		dev.Options = common.CreateBaseDeviceOptions(u)
-		d.devices[u] = dev
+		err := &common.NotFoundError{
+			Err: fmt.Sprintf("options not found for device UUID: %s", u),
+		}
+		return nil, err
 	}
 	return dev.Options, nil
 }
@@ -667,7 +674,10 @@ func (d *DeviceManager) GetGlobalOptions() ([]byte, error) {
 	d.m.Lock()
 	defer d.m.Unlock()
 	if d.globalOptions == nil {
-		d.globalOptions = common.CreateBaseGlobalOptions()
+		err := &common.NotFoundError{
+			Err: "global options not found",
+		}
+		return nil, err
 	}
 	return d.globalOptions, nil
 }

--- a/pkg/driver/memory/device_manager_memory_test.go
+++ b/pkg/driver/memory/device_manager_memory_test.go
@@ -653,7 +653,7 @@ func TestDeviceManagerMemory(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error generating a new device UUID: %v", err)
 			}
-			err = d.DeviceRegister(u, deviceCert, onboard, serial, common.CreateBaseConfig(u))
+			err = d.DeviceRegister(u, deviceCert, onboard, serial)
 			switch {
 			case (err != nil && tt.err == nil) || (err == nil && tt.err != nil) || (err != nil && tt.err != nil && !strings.HasPrefix(err.Error(), tt.err.Error())):
 				t.Errorf("%d: mismatched errors, actual %v expected %v", i, err, tt.err)

--- a/pkg/driver/redis/device_manager_redis.go
+++ b/pkg/driver/redis/device_manager_redis.go
@@ -447,7 +447,7 @@ func (d *DeviceManager) DeviceList() ([]*uuid.UUID, error) {
 }
 
 // DeviceRegister register a new device cert
-func (d *DeviceManager) DeviceRegister(unew uuid.UUID, cert, onboard *x509.Certificate, serial string, conf []byte) error {
+func (d *DeviceManager) DeviceRegister(unew uuid.UUID, cert, onboard *x509.Certificate, serial string) error {
 	// check if it already exists - this also checks for nil cert
 	u, err := d.DeviceCheckCert(cert)
 	if err != nil {
@@ -478,12 +478,6 @@ func (d *DeviceManager) DeviceRegister(unew uuid.UUID, cert, onboard *x509.Certi
 		if err != nil {
 			return fmt.Errorf("error saving device serial for %v: %v", unew, err)
 		}
-	}
-
-	// save the base configuration
-	err = d.writeJSONMsgPack(unew, deviceConfigsHash, conf)
-	if err != nil {
-		return fmt.Errorf("error saving device config for %v: %v", unew, err)
 	}
 
 	// save new one to cache - just the serial and onboard; the rest is on disk
@@ -769,14 +763,10 @@ func (d *DeviceManager) GetConfig(u uuid.UUID) ([]byte, error) {
 	data, err := d.client.HGet(deviceConfigsHash, u.String()).Result()
 	switch {
 	case err != nil && errors.Is(err, redis.Nil):
-		// if config doesn't exist - create an empty one
-		b = common.CreateBaseConfig(u)
-		if _, err = d.client.HSet(deviceConfigsHash, u.String(), string(b)).Result(); err == nil {
-			_, err = d.client.Save().Result()
+		err = &common.NotFoundError{
+			Err: fmt.Sprintf("config not found for device UUID %s", u),
 		}
-		if err != nil {
-			return nil, fmt.Errorf("failed to save config for %s: %v", u.String(), err)
-		}
+		return nil, err
 	case err != nil:
 		return nil, fmt.Errorf("failed to get config for %s: %v", u.String(), err)
 	default:
@@ -1078,14 +1068,14 @@ func (d *DeviceManager) transactionDrop(keys [][]string) (result error) {
 	for _, k := range keys {
 		switch len(k) {
 		case 1:
-			if i, err := d.client.Del(k[0]).Result(); i != 1 || err != nil {
-				result = fmt.Errorf("couldn't drop %s with error %d/%v (previous error in transaction %v)",
-					k[0], i, err, result)
+			if _, err := d.client.Del(k[0]).Result(); err != nil {
+				result = fmt.Errorf("couldn't drop %s: %v (previous error in transaction %v)",
+					k[0], err, result)
 			}
 		case 2:
-			if i, err := d.client.HDel(k[0], k[1]).Result(); i != 1 || err != nil {
-				result = fmt.Errorf("couldn't drop %s[%s] with error %d/%v (previous error in transaction %v)",
-					k[0], k[1], i, err, result)
+			if _, err := d.client.HDel(k[0], k[1]).Result(); err != nil {
+				result = fmt.Errorf("couldn't drop %s[%s]: %v (previous error in transaction %v)",
+					k[0], k[1], err, result)
 			}
 		default:
 			panic("transactionDrop should never be called with keys that are less than 1 or more than 2 elements")
@@ -1202,10 +1192,11 @@ func (d *DeviceManager) GetDeviceOptions(u uuid.UUID) ([]byte, error) {
 	}
 	data, err := d.client.HGet(deviceOptionsHash, u.String()).Result()
 	if err != nil {
-		cfg := common.CreateBaseDeviceOptions(u)
-		err = d.SetDeviceOptions(u, cfg)
-		if err == nil {
-			return cfg, nil
+		if errors.Is(err, redis.Nil) {
+			err = &common.NotFoundError{
+				Err: fmt.Sprintf("options not found for device UUID: %s", u),
+			}
+			return nil, err
 		}
 		return nil, fmt.Errorf("failed to get options for %s: %v", u.String(), err)
 	} else {
@@ -1231,10 +1222,11 @@ func (d *DeviceManager) SetGlobalOptions(b []byte) error {
 func (d *DeviceManager) GetGlobalOptions() ([]byte, error) {
 	data, err := d.client.HGet(globalOptionsHash, globalOptionsHash).Result()
 	if err != nil {
-		cfg := common.CreateBaseGlobalOptions()
-		err = d.SetGlobalOptions(cfg)
-		if err == nil {
-			return cfg, nil
+		if errors.Is(err, redis.Nil) {
+			err = &common.NotFoundError{
+				Err: "global options not found",
+			}
+			return nil, err
 		}
 		return nil, fmt.Errorf("failed to get options for %s: %v", globalOptionsHash, err)
 	} else {

--- a/pkg/driver/redis/device_manager_redis_test.go
+++ b/pkg/driver/redis/device_manager_redis_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/lf-edge/eve-api/go/metrics"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -94,20 +93,20 @@ func TestDeviceRedis(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to generate new UUID: %v", err)
 	}
-	err = r.DeviceRegister(UUID2, cert2, certOnboard, "------", common.CreateBaseConfig(UUID2))
+	err = r.DeviceRegister(UUID2, cert2, certOnboard, "------")
 	assert.Equal(t, nil, err)
 	UUID3, err := uuid.NewV4()
 	if err != nil {
 		t.Fatalf("unable to generate new UUID: %v", err)
 	}
-	err = r.DeviceRegister(UUID3, cert3, certOnboard, "------", common.CreateBaseConfig(UUID3))
+	err = r.DeviceRegister(UUID3, cert3, certOnboard, "------")
 	assert.Equal(t, nil, err)
 
 	UUID1, err := uuid.NewV4()
 	if err != nil {
 		t.Fatalf("unable to generate new UUID: %v", err)
 	}
-	err = r.DeviceRegister(UUID1, cert, certOnboard, "123456", common.CreateBaseConfig(UUID1))
+	err = r.DeviceRegister(UUID1, cert, certOnboard, "123456")
 	assert.Equal(t, nil, err)
 	UUID, err := r.DeviceCheckCert(cert)
 	assert.Equal(t, nil, err)
@@ -163,37 +162,35 @@ func TestConfigRedis(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to generate new UUID: %v", err)
 	}
-	err = r.DeviceRegister(UUID, cert, certOnboard, "123456", common.CreateBaseConfig(UUID))
+	err = r.DeviceRegister(UUID, cert, certOnboard, "123456")
 	assert.Equal(t, nil, err)
 
-	conf, err := r.GetConfig(UUID)
-	assert.Equal(t, nil, err)
-	// convert to struct
-	var msg config.EdgeDevConfig
-	if err := proto.Unmarshal(conf, &msg); err != nil {
-		t.Fatalf("error converting device config bytes to struct: %v", err)
+	// No config has been submitted yet — expect NotFoundError.
+	_, err = r.GetConfig(UUID)
+	_, isNotFound := err.(*common.NotFoundError)
+	assert.True(t, isNotFound)
+
+	// Submit a config and verify round-trip.
+	msg := config.EdgeDevConfig{
+		Id: &config.UUIDandVersion{
+			Uuid:    UUID.String(),
+			Version: "1",
+		},
 	}
-
-	assert.Equal(t, UUID.String(), msg.GetId().Uuid)
-	assert.Equal(t, "4", msg.GetId().Version)
-
-	// convert to bytes
-	conf, err = protojson.Marshal(&msg)
+	conf, err := proto.Marshal(&msg)
 	if err != nil {
-		t.Fatalf("error converting device config struct to bytes: %v", err)
+		t.Fatalf("error marshaling device config: %v", err)
 	}
-
 	assert.Equal(t, nil, r.SetConfig(UUID, conf))
 
 	conf, err = r.GetConfig(UUID)
-	// convert to struct
-	if err := protojson.Unmarshal(conf, &msg); err != nil {
+	assert.Equal(t, nil, err)
+	var got config.EdgeDevConfig
+	if err := proto.Unmarshal(conf, &got); err != nil {
 		t.Fatalf("error converting device config bytes to struct: %v", err)
 	}
-
-	assert.Equal(t, nil, err)
-	assert.Equal(t, UUID.String(), msg.GetId().Uuid)
-	assert.Equal(t, "4", msg.GetId().Version)
+	assert.Equal(t, UUID.String(), got.GetId().Uuid)
+	assert.Equal(t, "1", got.GetId().Version)
 }
 
 func TestStreamsRedis(t *testing.T) {
@@ -212,7 +209,7 @@ func TestStreamsRedis(t *testing.T) {
 	cert := generateCert(t, "cert", "host")
 	certOnboard := generateCert(t, "onboard", "host")
 
-	err = r.DeviceRegister(u, cert, certOnboard, "123456", common.CreateBaseConfig(u))
+	err = r.DeviceRegister(u, cert, certOnboard, "123456")
 	assert.Equal(t, nil, err)
 
 	var (
@@ -261,6 +258,9 @@ func TestStreamsRedis(t *testing.T) {
 			break
 		}
 		assert.Equal(t, nil, err)
+		if s == 0 {
+			continue
+		}
 		l, err := lr.Read(buffer)
 		assert.Equal(t, nil, err)
 		assert.Equal(t, int64(l), s)
@@ -274,6 +274,9 @@ func TestStreamsRedis(t *testing.T) {
 			break
 		}
 		assert.Equal(t, nil, err)
+		if s == 0 {
+			continue
+		}
 		l, err := lr.Read(buffer)
 		assert.Equal(t, nil, err)
 		assert.Equal(t, int64(l), s)
@@ -320,7 +323,7 @@ func TestDeviceManagerRedisConcurrency(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ParseCertificate: %v", err)
 			}
-			if err := d.DeviceRegister(uids[i], cert, nil, "", common.CreateBaseConfig(uids[i])); err != nil {
+			if err := d.DeviceRegister(uids[i], cert, nil, ""); err != nil {
 				t.Fatalf("DeviceRegister: %v", err)
 			}
 		}

--- a/pkg/server/adminHandler.go
+++ b/pkg/server/adminHandler.go
@@ -193,7 +193,7 @@ func (h *adminHandler) deviceAdd(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("error generating a new device UUID: %v", err), http.StatusBadRequest)
 		return
 	}
-	if err := h.manager.DeviceRegister(unew, cert, onboard, t.Serial, common.CreateBaseConfig(unew)); err != nil {
+	if err := h.manager.DeviceRegister(unew, cert, onboard, t.Serial); err != nil {
 		log.Printf("deviceAdd: DeviceRegister error: %v", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
@@ -344,40 +344,40 @@ func (h *adminHandler) deviceConfigSet(w http.ResponseWriter, r *http.Request) {
 	}
 	// before setting the config, set any necessary defaults
 	// check for UUID and/or version mismatch
-	var (
-		existingId     *config.UUIDandVersion
-		existingConfig config.EdgeDevConfig
-	)
+	var existingId *config.UUIDandVersion
 	existingConfigB, err := h.manager.GetConfig(uid)
-	_, isNotFound := err.(*common.NotFoundError)
-	switch {
-	case err != nil && isNotFound:
-		http.Error(w, fmt.Sprintf("device not found %s", u), http.StatusNotFound)
-		return
-	case err != nil:
-		log.Printf("deviceConfigSet: GetConfig error: %v", err)
-		http.Error(w, fmt.Sprintf("error retrieving existing config for device %s: %v", u, err), http.StatusBadRequest)
-		return
-	case len(existingConfigB) == 0:
-		http.Error(w, "found device information, but had no config", http.StatusInternalServerError)
-		return
+	if err != nil {
+		// If the device is not found, SetConfig will fail.
+		// If the device is registered but no config has been applied yet, this is OK;
+		// we apply the initial configuration.
+		_, isNotFound := err.(*common.NotFoundError)
+		if !isNotFound {
+			log.Printf("deviceConfigSet: GetConfig error: %v", err)
+			errMsg := fmt.Sprintf("error retrieving existing config for device %s: %v", u, err)
+			http.Error(w, errMsg, http.StatusInternalServerError)
+			return
+		}
+	} else {
+		var existingConfig config.EdgeDevConfig
+		if err := proto.Unmarshal(existingConfigB, &existingConfig); err != nil {
+			log.Printf("deviceConfigSet: processing existing config error: %v", err)
+			errMsg := fmt.Sprintf("error processing existing config: %v", err)
+			http.Error(w, errMsg, http.StatusInternalServerError)
+			return
+		}
+		existingId = existingConfig.GetId()
 	}
-	// convert it to protobuf so we can work with it
-	if err := proto.Unmarshal(existingConfigB, &existingConfig); err != nil {
-		log.Printf("deviceConfigSet: processing existing config error: %v", err)
-		http.Error(w, fmt.Sprintf("error processing existing config: %v", err), http.StatusInternalServerError)
-		return
-	}
-	existingId = existingConfig.Id
 
 	// we only can bump the version if it is a valid integer
-	newVersion, versionError := strconv.Atoi(existingId.Version)
+	newVersion, versionError := strconv.Atoi(existingId.GetVersion())
 	if versionError == nil {
 		newVersion++
 	}
 	if deviceConfig.Id == nil {
 		if versionError != nil {
-			http.Error(w, fmt.Sprintf("cannot automatically non-number bump version %s", existingId.Version), http.StatusBadRequest)
+			errMsg := fmt.Sprintf("cannot automatically non-number bump version %s",
+				existingId.GetVersion())
+			http.Error(w, errMsg, http.StatusBadRequest)
 			return
 		}
 		deviceConfig.Id = &config.UUIDandVersion{
@@ -390,13 +390,17 @@ func (h *adminHandler) deviceConfigSet(w http.ResponseWriter, r *http.Request) {
 		}
 		if deviceConfig.Id.Version == "" {
 			if versionError != nil {
-				http.Error(w, fmt.Sprintf("cannot automatically non-number bump version %s", existingId.Version), http.StatusBadRequest)
+				errMsg := fmt.Sprintf("cannot automatically non-number bump version %s",
+					existingId.GetVersion())
+				http.Error(w, errMsg, http.StatusBadRequest)
 				return
 			}
 			deviceConfig.Id.Version = strconv.Itoa(newVersion)
 		}
 		if deviceConfig.Id.Uuid != u {
-			http.Error(w, fmt.Sprintf("mismatched UUID, setting %s for device %s", deviceConfig.Id.Uuid, u), http.StatusBadRequest)
+			errMsg := fmt.Sprintf("mismatched UUID, setting %s for device %s",
+				deviceConfig.Id.Uuid, u)
+			http.Error(w, errMsg, http.StatusBadRequest)
 			return
 		}
 	}
@@ -404,11 +408,12 @@ func (h *adminHandler) deviceConfigSet(w http.ResponseWriter, r *http.Request) {
 	b, err := proto.Marshal(&deviceConfig)
 	if err != nil {
 		log.Printf("deviceConfigSet: Marshal error: %v", err)
-		http.Error(w, fmt.Sprintf("error processing device config: %v", err), http.StatusBadRequest)
+		errMsg := fmt.Sprintf("error processing device config: %v", err)
+		http.Error(w, errMsg, http.StatusBadRequest)
 		return
 	}
 	err = h.manager.SetConfig(uid, b)
-	_, isNotFound = err.(*common.NotFoundError)
+	_, isNotFound := err.(*common.NotFoundError)
 	switch {
 	case err != nil && isNotFound:
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)

--- a/pkg/server/apiHandler.go
+++ b/pkg/server/apiHandler.go
@@ -113,6 +113,11 @@ func (h *apiHandler) configPost(w http.ResponseWriter, r *http.Request) {
 	}
 	cfg, err := h.manager.GetConfig(*u)
 	if err != nil {
+		if _, isNotFound := err.(*common.NotFoundError); isNotFound {
+			log.Printf("config not found for device %s", u)
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
 		log.Printf("error getting device config: %v", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
@@ -145,6 +150,11 @@ func (h *apiHandler) config(w http.ResponseWriter, r *http.Request) {
 	}
 	cfg, err := h.manager.GetConfig(*u)
 	if err != nil {
+		if _, isNotFound := err.(*common.NotFoundError); isNotFound {
+			log.Printf("config not found for device %s", u)
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
 		log.Printf("error getting device config: %v", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return

--- a/pkg/server/apiHandlerv2.go
+++ b/pkg/server/apiHandlerv2.go
@@ -489,6 +489,11 @@ func (h *apiHandlerv2) config(w http.ResponseWriter, r *http.Request) {
 	}
 	cfg, err := h.manager.GetConfig(*u)
 	if err != nil {
+		if _, isNotFound := err.(*common.NotFoundError); isNotFound {
+			log.Printf("config not found for device %s", u)
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
 		log.Printf("error getting device config: %v", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return

--- a/pkg/server/commonHandler.go
+++ b/pkg/server/commonHandler.go
@@ -147,7 +147,7 @@ func registerProcess(manager driver.DeviceManager, registerMessage []byte, onboa
 		return http.StatusBadRequest, fmt.Errorf("error generating a new device UUID: %v", err)
 	}
 	// we do not keep the uuid or send it back; perhaps a future version of the API will support it
-	if err := manager.DeviceRegister(unew, deviceCert, onboardCert, serial, common.CreateBaseConfig(unew)); err != nil {
+	if err := manager.DeviceRegister(unew, deviceCert, onboardCert, serial); err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("error registering new device: %v", err)
 	}
 	// send back a 201
@@ -293,7 +293,11 @@ func setDeviceOptions(manager driver.DeviceManager, u uuid.UUID, deviceOptions *
 func getDeviceOptions(manager driver.DeviceManager, u uuid.UUID) (*common.DeviceOptions, error) {
 	deviceOptionsBytes, err := manager.GetDeviceOptions(u)
 	if err != nil {
-		return nil, fmt.Errorf("getDeviceOptions failed to get from manager: %s", err)
+		if _, isNotFound := err.(*common.NotFoundError); isNotFound {
+			return &common.DeviceOptions{}, nil
+		} else {
+			return nil, fmt.Errorf("getDeviceOptions failed to get from manager: %s", err)
+		}
 	}
 	var deviceOptions common.DeviceOptions
 	if err := json.Unmarshal(deviceOptionsBytes, &deviceOptions); err != nil {
@@ -305,7 +309,11 @@ func getDeviceOptions(manager driver.DeviceManager, u uuid.UUID) (*common.Device
 func getGlobalOptions(manager driver.DeviceManager) (*common.GlobalOptions, error) {
 	globalOptionsBytes, err := manager.GetGlobalOptions()
 	if err != nil {
-		return nil, fmt.Errorf("getGlobalOptions failed to get from manager: %s", err)
+		if _, isNotFound := err.(*common.NotFoundError); isNotFound {
+			return &common.GlobalOptions{}, nil
+		} else {
+			return nil, fmt.Errorf("getGlobalOptions failed to get from manager: %s", err)
+		}
 	}
 	var globalOptions common.GlobalOptions
 	if err := json.Unmarshal(globalOptionsBytes, &globalOptions); err != nil {


### PR DESCRIPTION
Previously, Adam automatically created a minimal "base" config for every newly registered device. This caused two problems:

1. It made it impossible to test the scenario where the controller has no config for a device yet, which is a legitimate scenario that test frameworks need to exercise.

2. Devices can be provisioned with a bootstrap config baked in, which is necessary when the default network setup (DHCP on all Ethernet interfaces) does not provide controller connectivity -- for example when the network uses static IP addresses, VLANs, or a HTTP proxy for management traffic. If the test framework was too slow to submit the initial config, the device would fetch the auto-generated base config first, effectively overwriting the bootstrap config (and breaking connectivity for a while, until network config fallback kicks in). This forced the test framework to race against the first device config poll, an inherently fragile arrangement.

With this change, `GetConfig` returns `NotFoundError` when no config has been submitted yet. The API handlers propagate this as an HTTP 404, allowing the device to retry. `GetDeviceOptions` and `GetGlobalOptions` likewise return `NotFoundError` instead of auto-creating defaults; their callers treat not-found as "use zero-value defaults".

I have also enhanced the CI workflow to include running a Redis container. Previously, all Redis tests were silently skipped because no Redis instance was available.