### PR TITLE
Add admin API endpoints for app logs and flow records

### DIFF
--- a/pkg/driver/common/common.go
+++ b/pkg/driver/common/common.go
@@ -44,6 +44,15 @@ type ChunkReader interface {
 	Next() (io.Reader, int64, error)
 }
 
+// EmptyChunkReader is a ChunkReader implementation that contains no chunks.
+// Its Next method always returns io.EOF, indicating that no data is available.
+type EmptyChunkReader struct{}
+
+// Next always returns io.EOF because there are no chunks.
+func (EmptyChunkReader) Next() (io.Reader, int64, error) {
+	return nil, 0, io.EOF
+}
+
 type BigData interface {
 	Get(index int) ([]byte, error)
 	Reader() (ChunkReader, error)

--- a/pkg/driver/device_manager.go
+++ b/pkg/driver/device_manager.go
@@ -101,7 +101,9 @@ type DeviceManager interface {
 	GetRequestsReader(u uuid.UUID) (common.ChunkReader, error)
 	// GetAppLogsReader returns a logs reader for the specified application
 	// on the given device.
-	GetAppLogsReader(device, app uuid.UUID) (common.ChunkReader, error)
+	GetAppLogsReader(devID, appID uuid.UUID) (common.ChunkReader, error)
+	// GetFlowMessageReader returns a flow-message reader for the specified device.
+	GetFlowMessageReader(devID uuid.UUID) (common.ChunkReader, error)
 	// GetCerts retrieve the attest certs for a particular device
 	GetCerts(uid uuid.UUID) ([]byte, error)
 	// GetStorageKeys retrieve storage keys for a particular device

--- a/pkg/driver/device_manager.go
+++ b/pkg/driver/device_manager.go
@@ -99,6 +99,9 @@ type DeviceManager interface {
 	GetMetricsReader(u uuid.UUID) (common.ChunkReader, error)
 	// GetRequestsReader get the request logs for a given uuid
 	GetRequestsReader(u uuid.UUID) (common.ChunkReader, error)
+	// GetAppLogsReader returns a logs reader for the specified application
+	// on the given device.
+	GetAppLogsReader(device, app uuid.UUID) (common.ChunkReader, error)
 	// GetCerts retrieve the attest certs for a particular device
 	GetCerts(uid uuid.UUID) ([]byte, error)
 	// GetStorageKeys retrieve storage keys for a particular device

--- a/pkg/driver/file/device_manager_file.go
+++ b/pkg/driver/file/device_manager_file.go
@@ -1227,16 +1227,27 @@ func (d *DeviceManager) GetRequestsReader(u uuid.UUID) (common.ChunkReader, erro
 
 // GetAppLogsReader returns a logs reader for the specified application
 // on the given device.
-func (d *DeviceManager) GetAppLogsReader(device, app uuid.UUID) (common.ChunkReader, error) {
+func (d *DeviceManager) GetAppLogsReader(devID, appID uuid.UUID) (common.ChunkReader, error) {
 	d.m.Lock()
 	defer d.m.Unlock()
-	if !d.deviceExists(device) {
-		return nil, fmt.Errorf("unregistered device UUID: %s", device)
+	if !d.deviceExists(devID) {
+		return nil, fmt.Errorf("unregistered device UUID: %s", devID)
 	}
-	if !d.appExists(device, app) {
+	if !d.appExists(devID, appID) {
 		return common.EmptyChunkReader{}, nil
 	}
-	return d.devices[device].AppLogs[app].Reader()
+	return d.devices[devID].AppLogs[appID].Reader()
+}
+
+// GetFlowMessageReader returns a flow-message reader for the specified device.
+func (d *DeviceManager) GetFlowMessageReader(devID uuid.UUID) (common.ChunkReader, error) {
+	d.m.Lock()
+	defer d.m.Unlock()
+	// check that the device actually exists
+	if !d.deviceExists(devID) {
+		return nil, fmt.Errorf("unregistered device UUID: %s", devID)
+	}
+	return d.devices[devID].FlowMessage.Reader()
 }
 
 // WriteFlowMessage write FlowMessage

--- a/pkg/driver/file/device_manager_file.go
+++ b/pkg/driver/file/device_manager_file.go
@@ -1087,9 +1087,9 @@ func (d *DeviceManager) getOnboardPath(cn string) string {
 	return path.Join(d.databasePath, onboardDir, cn)
 }
 
-func openTimestampFile(filename string) (*os.File, error) {
+func openTimestampFile(dirname string) (*os.File, error) {
 	// open a new one
-	fullPath := path.Join(filename, time.Now().Format("2006-01-02T15:04:05.111"))
+	fullPath := path.Join(dirname, fmt.Sprintf("%020d", time.Now().UnixNano()))
 	return os.Create(fullPath)
 }
 

--- a/pkg/driver/file/device_manager_file.go
+++ b/pkg/driver/file/device_manager_file.go
@@ -758,8 +758,12 @@ func (d *DeviceManager) WriteAppInstanceLogs(instanceID uuid.UUID, deviceID uuid
 		return fmt.Errorf("unregistered device UUID: %s", deviceID)
 	}
 	if !d.appExists(deviceID, instanceID) {
+		appDir := d.getAppPath(deviceID, instanceID)
+		if err := os.MkdirAll(appDir, 0755); err != nil {
+			return fmt.Errorf("failed to create app log directory %s: %v", appDir, err)
+		}
 		d.devices[deviceID].AppLogs[instanceID] = &ManagedFile{
-			dir:     d.getAppPath(deviceID, instanceID),
+			dir:     appDir,
 			maxSize: int64(d.maxAppLogsSize),
 		}
 	}

--- a/pkg/driver/file/device_manager_file.go
+++ b/pkg/driver/file/device_manager_file.go
@@ -529,7 +529,7 @@ func (d *DeviceManager) initDevice(u uuid.UUID) error {
 	}
 
 	// create the necessary directories for data uploads
-	for _, p := range []string{logDir, metricsDir, infoDir, requestsDir} {
+	for _, p := range []string{logDir, metricsDir, infoDir, requestsDir, flowMessageDir} {
 		cur := path.Join(devicePath, p)
 		err = os.MkdirAll(cur, 0755)
 		if err != nil {

--- a/pkg/driver/file/device_manager_file.go
+++ b/pkg/driver/file/device_manager_file.go
@@ -740,6 +740,9 @@ func (d *DeviceManager) appExists(u, instanceID uuid.UUID) bool {
 	if _, ok := d.devices[u]; !ok {
 		return false
 	}
+	if _, ok := d.devices[u].AppLogs[instanceID]; !ok {
+		return false
+	}
 	return true
 }
 
@@ -1220,6 +1223,20 @@ func (d *DeviceManager) GetRequestsReader(u uuid.UUID) (common.ChunkReader, erro
 		return nil, fmt.Errorf("unregistered device UUID: %s", u)
 	}
 	return dev.Requests.Reader()
+}
+
+// GetAppLogsReader returns a logs reader for the specified application
+// on the given device.
+func (d *DeviceManager) GetAppLogsReader(device, app uuid.UUID) (common.ChunkReader, error) {
+	d.m.Lock()
+	defer d.m.Unlock()
+	if !d.deviceExists(device) {
+		return nil, fmt.Errorf("unregistered device UUID: %s", device)
+	}
+	if !d.appExists(device, app) {
+		return common.EmptyChunkReader{}, nil
+	}
+	return d.devices[device].AppLogs[app].Reader()
 }
 
 // WriteFlowMessage write FlowMessage

--- a/pkg/driver/memory/device_manager_memory.go
+++ b/pkg/driver/memory/device_manager_memory.go
@@ -603,16 +603,28 @@ func (d *DeviceManager) GetRequestsReader(u uuid.UUID) (common.ChunkReader, erro
 
 // GetAppLogsReader returns a logs reader for the specified application
 // on the given device.
-func (d *DeviceManager) GetAppLogsReader(device, app uuid.UUID) (common.ChunkReader, error) {
+func (d *DeviceManager) GetAppLogsReader(devID, appID uuid.UUID) (common.ChunkReader, error) {
 	d.m.Lock()
 	defer d.m.Unlock()
-	if _, ok := d.devices[device]; !ok {
-		return nil, fmt.Errorf("unregistered device UUID %s", device.String())
+	dev, ok := d.devices[devID]
+	if !ok {
+		return nil, fmt.Errorf("unregistered device UUID %s", devID.String())
 	}
-	if !d.appExists(device, app) {
+	if !d.appExists(devID, appID) {
 		return common.EmptyChunkReader{}, nil
 	}
-	return d.devices[device].AppLogs[app].Reader()
+	return dev.AppLogs[appID].Reader()
+}
+
+// GetFlowMessageReader returns a flow-message reader for the specified device.
+func (d *DeviceManager) GetFlowMessageReader(devID uuid.UUID) (common.ChunkReader, error) {
+	d.m.Lock()
+	defer d.m.Unlock()
+	dev, ok := d.devices[devID]
+	if !ok {
+		return nil, fmt.Errorf("unregistered device UUID %s", devID.String())
+	}
+	return dev.FlowMessage.Reader()
 }
 
 // WriteFlowMessage write FlowMessage

--- a/pkg/driver/memory/device_manager_memory.go
+++ b/pkg/driver/memory/device_manager_memory.go
@@ -601,6 +601,20 @@ func (d *DeviceManager) GetRequestsReader(u uuid.UUID) (common.ChunkReader, erro
 	return dev.Requests.Reader()
 }
 
+// GetAppLogsReader returns a logs reader for the specified application
+// on the given device.
+func (d *DeviceManager) GetAppLogsReader(device, app uuid.UUID) (common.ChunkReader, error) {
+	d.m.Lock()
+	defer d.m.Unlock()
+	if _, ok := d.devices[device]; !ok {
+		return nil, fmt.Errorf("unregistered device UUID %s", device.String())
+	}
+	if !d.appExists(device, app) {
+		return common.EmptyChunkReader{}, nil
+	}
+	return d.devices[device].AppLogs[app].Reader()
+}
+
 // WriteFlowMessage write FlowMessage
 func (d *DeviceManager) WriteFlowMessage(u uuid.UUID, b []byte) error {
 	// make sure it is not nil

--- a/pkg/driver/redis/device_manager_redis.go
+++ b/pkg/driver/redis/device_manager_redis.go
@@ -856,6 +856,20 @@ func (d *DeviceManager) GetRequestsReader(u uuid.UUID) (common.ChunkReader, erro
 	return dev.Requests.Reader()
 }
 
+// GetAppLogsReader returns a logs reader for the specified application
+// on the given device.
+func (d *DeviceManager) GetAppLogsReader(device, app uuid.UUID) (common.ChunkReader, error) {
+	d.m.Lock()
+	defer d.m.Unlock()
+	if _, ok := d.devices[device]; !ok {
+		return nil, fmt.Errorf("unregistered device UUID %s", device.String())
+	}
+	if !d.appExists(device, app) {
+		return common.EmptyChunkReader{}, nil
+	}
+	return d.devices[device].AppLogs[app].Reader()
+}
+
 // refreshCache refresh cache from disk.
 // If isLocked is true the caller already holds d.m; otherwise refreshCache acquires it.
 func (d *DeviceManager) refreshCache(isLocked bool) error {

--- a/pkg/driver/redis/device_manager_redis.go
+++ b/pkg/driver/redis/device_manager_redis.go
@@ -858,16 +858,28 @@ func (d *DeviceManager) GetRequestsReader(u uuid.UUID) (common.ChunkReader, erro
 
 // GetAppLogsReader returns a logs reader for the specified application
 // on the given device.
-func (d *DeviceManager) GetAppLogsReader(device, app uuid.UUID) (common.ChunkReader, error) {
+func (d *DeviceManager) GetAppLogsReader(devID, appID uuid.UUID) (common.ChunkReader, error) {
 	d.m.Lock()
 	defer d.m.Unlock()
-	if _, ok := d.devices[device]; !ok {
-		return nil, fmt.Errorf("unregistered device UUID %s", device.String())
+	dev, ok := d.devices[devID]
+	if !ok {
+		return nil, fmt.Errorf("unregistered device UUID %s", devID.String())
 	}
-	if !d.appExists(device, app) {
+	if !d.appExists(devID, appID) {
 		return common.EmptyChunkReader{}, nil
 	}
-	return d.devices[device].AppLogs[app].Reader()
+	return dev.AppLogs[appID].Reader()
+}
+
+// GetFlowMessageReader returns a flow-message reader for the specified device.
+func (d *DeviceManager) GetFlowMessageReader(devID uuid.UUID) (common.ChunkReader, error) {
+	d.m.Lock()
+	defer d.m.Unlock()
+	dev, ok := d.devices[devID]
+	if !ok {
+		return nil, fmt.Errorf("unregistered device UUID: %s", devID)
+	}
+	return dev.FlowMessage.Reader()
 }
 
 // refreshCache refresh cache from disk.

--- a/pkg/server/adminHandler.go
+++ b/pkg/server/adminHandler.go
@@ -18,8 +18,6 @@ import (
 	"github.com/lf-edge/adam/pkg/driver/common"
 	ax "github.com/lf-edge/adam/pkg/x509"
 	"github.com/lf-edge/eve-api/go/config"
-	"github.com/lf-edge/eve-api/go/info"
-	"github.com/lf-edge/eve-api/go/metrics"
 	uuid "github.com/satori/go.uuid"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -425,69 +423,46 @@ func (h *adminHandler) deviceLogsGet(w http.ResponseWriter, r *http.Request) {
 	readerFunc := func(id instanceID) (common.ChunkReader, error) {
 		return h.manager.GetLogsReader(id.devUUID)
 	}
-	h.deviceDataGet(w, r, h.logStream, readerFunc, nil)
+	h.deviceDataGet(w, r, h.logStream, readerFunc)
 }
 
 func (h *adminHandler) deviceInfoGet(w http.ResponseWriter, r *http.Request) {
 	readerFunc := func(id instanceID) (common.ChunkReader, error) {
 		return h.manager.GetInfoReader(id.devUUID)
 	}
-	h.deviceDataGet(w, r, h.infoStream, readerFunc, func(in []byte) ([]byte, error) {
-		var err error
-		msg := &info.ZInfoMsg{}
-		if err = proto.Unmarshal(in, msg); err != nil {
-			return nil, fmt.Errorf("error parsing info message: %v", err)
-		}
-		var entryBytes []byte
-		if entryBytes, err = protojson.Marshal(msg); err != nil {
-			return nil, fmt.Errorf("failed to marshal info message: %v", err)
-		}
-		return entryBytes, nil
-	})
+	h.deviceDataGet(w, r, h.infoStream, readerFunc)
 }
 
 func (h *adminHandler) deviceRequestsGet(w http.ResponseWriter, r *http.Request) {
 	readerFunc := func(id instanceID) (common.ChunkReader, error) {
 		return h.manager.GetRequestsReader(id.devUUID)
 	}
-	h.deviceDataGet(w, r, h.requestsStream, readerFunc, nil)
+	h.deviceDataGet(w, r, h.requestsStream, readerFunc)
 }
 
 func (h *adminHandler) deviceMetricsGet(w http.ResponseWriter, r *http.Request) {
 	readerFunc := func(id instanceID) (common.ChunkReader, error) {
 		return h.manager.GetMetricsReader(id.devUUID)
 	}
-	h.deviceDataGet(w, r, h.metricsStream, readerFunc, func(in []byte) ([]byte, error) {
-		var err error
-		msg := &metrics.ZMetricMsg{}
-		if err = proto.Unmarshal(in, msg); err != nil {
-			return nil, fmt.Errorf("error parsing metrics message: %v", err)
-		}
-		var entryBytes []byte
-		if entryBytes, err = protojson.Marshal(msg); err != nil {
-			return nil, fmt.Errorf("failed to marshal metrics message: %v", err)
-		}
-		return entryBytes, nil
-	})
+	h.deviceDataGet(w, r, h.metricsStream, readerFunc)
 }
 
 func (h *adminHandler) appLogsGet(w http.ResponseWriter, r *http.Request) {
 	readerFunc := func(id instanceID) (common.ChunkReader, error) {
 		return h.manager.GetAppLogsReader(id.devUUID, id.appUUID)
 	}
-	h.deviceDataGet(w, r, h.logStream, readerFunc, nil)
+	h.deviceDataGet(w, r, h.logStream, readerFunc)
 }
 
 func (h *adminHandler) deviceFlowlogsGet(w http.ResponseWriter, r *http.Request) {
 	readerFunc := func(id instanceID) (common.ChunkReader, error) {
 		return h.manager.GetFlowMessageReader(id.devUUID)
 	}
-	h.deviceDataGet(w, r, h.flowlogsStream, readerFunc, nil)
+	h.deviceDataGet(w, r, h.flowlogsStream, readerFunc)
 }
 
 func (h *adminHandler) deviceDataGet(w http.ResponseWriter, r *http.Request,
-	s *stream, readerFunc func(instanceID) (common.ChunkReader, error),
-	conversionFunc func(in []byte) ([]byte, error)) {
+	s *stream, readerFunc func(instanceID) (common.ChunkReader, error)) {
 	var id instanceID
 	var err error
 	uuidStr := mux.Vars(r)["uuid"]
@@ -502,10 +477,6 @@ func (h *adminHandler) deviceDataGet(w http.ResponseWriter, r *http.Request,
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-	}
-	conversionRequired := false
-	if conversionFunc != nil {
-		conversionRequired = acceptJSON(r)
 	}
 	watch := r.Header.Get(StreamHeader)
 	if watch == StreamValue {
@@ -532,13 +503,6 @@ func (h *adminHandler) deviceDataGet(w http.ResponseWriter, r *http.Request,
 		for {
 			select {
 			case b := <-c:
-				if conversionRequired {
-					b, err = conversionFunc(b)
-					if err != nil {
-						log.Printf("conversionFunc failed: %v", err)
-						continue
-					}
-				}
 				w.Write(append(b, 0x0a))
 				flusher.Flush()
 			case <-cn.CloseNotify():
@@ -573,13 +537,6 @@ func (h *adminHandler) deviceDataGet(w http.ResponseWriter, r *http.Request,
 					if err != nil && err != io.EOF {
 						http.Error(w, fmt.Sprintf("error reading data: %v", err), http.StatusInternalServerError)
 						continue
-					}
-					if conversionRequired {
-						buf, err = conversionFunc(buf)
-						if err != nil {
-							log.Printf("conversionFunc failed: %v", err)
-							continue
-						}
 					}
 					w.Write(append(buf, 0x0a))
 				}

--- a/pkg/server/adminHandler.go
+++ b/pkg/server/adminHandler.go
@@ -36,6 +36,7 @@ type adminHandler struct {
 	infoStream     *stream
 	requestsStream *stream
 	metricsStream  *stream
+	flowlogsStream *stream
 }
 
 // OnboardCert encoding for sending an onboard cert and serials via json
@@ -475,6 +476,13 @@ func (h *adminHandler) appLogsGet(w http.ResponseWriter, r *http.Request) {
 		return h.manager.GetAppLogsReader(id.devUUID, id.appUUID)
 	}
 	h.deviceDataGet(w, r, h.logStream, readerFunc, nil)
+}
+
+func (h *adminHandler) deviceFlowlogsGet(w http.ResponseWriter, r *http.Request) {
+	readerFunc := func(id instanceID) (common.ChunkReader, error) {
+		return h.manager.GetFlowMessageReader(id.devUUID)
+	}
+	h.deviceDataGet(w, r, h.flowlogsStream, readerFunc, nil)
 }
 
 func (h *adminHandler) deviceDataGet(w http.ResponseWriter, r *http.Request,

--- a/pkg/server/adminHandler.go
+++ b/pkg/server/adminHandler.go
@@ -421,11 +421,17 @@ func (h *adminHandler) deviceConfigSet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *adminHandler) deviceLogsGet(w http.ResponseWriter, r *http.Request) {
-	h.deviceDataGet(w, r, h.logStream, h.manager.GetLogsReader, nil)
+	readerFunc := func(id instanceID) (common.ChunkReader, error) {
+		return h.manager.GetLogsReader(id.devUUID)
+	}
+	h.deviceDataGet(w, r, h.logStream, readerFunc, nil)
 }
 
 func (h *adminHandler) deviceInfoGet(w http.ResponseWriter, r *http.Request) {
-	h.deviceDataGet(w, r, h.infoStream, h.manager.GetInfoReader, func(in []byte) ([]byte, error) {
+	readerFunc := func(id instanceID) (common.ChunkReader, error) {
+		return h.manager.GetInfoReader(id.devUUID)
+	}
+	h.deviceDataGet(w, r, h.infoStream, readerFunc, func(in []byte) ([]byte, error) {
 		var err error
 		msg := &info.ZInfoMsg{}
 		if err = proto.Unmarshal(in, msg); err != nil {
@@ -440,11 +446,17 @@ func (h *adminHandler) deviceInfoGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *adminHandler) deviceRequestsGet(w http.ResponseWriter, r *http.Request) {
-	h.deviceDataGet(w, r, h.requestsStream, h.manager.GetRequestsReader, nil)
+	readerFunc := func(id instanceID) (common.ChunkReader, error) {
+		return h.manager.GetRequestsReader(id.devUUID)
+	}
+	h.deviceDataGet(w, r, h.requestsStream, readerFunc, nil)
 }
 
 func (h *adminHandler) deviceMetricsGet(w http.ResponseWriter, r *http.Request) {
-	h.deviceDataGet(w, r, h.metricsStream, h.manager.GetMetricsReader, func(in []byte) ([]byte, error) {
+	readerFunc := func(id instanceID) (common.ChunkReader, error) {
+		return h.manager.GetMetricsReader(id.devUUID)
+	}
+	h.deviceDataGet(w, r, h.metricsStream, readerFunc, func(in []byte) ([]byte, error) {
 		var err error
 		msg := &metrics.ZMetricMsg{}
 		if err = proto.Unmarshal(in, msg); err != nil {
@@ -458,14 +470,30 @@ func (h *adminHandler) deviceMetricsGet(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
+func (h *adminHandler) appLogsGet(w http.ResponseWriter, r *http.Request) {
+	readerFunc := func(id instanceID) (common.ChunkReader, error) {
+		return h.manager.GetAppLogsReader(id.devUUID, id.appUUID)
+	}
+	h.deviceDataGet(w, r, h.logStream, readerFunc, nil)
+}
+
 func (h *adminHandler) deviceDataGet(w http.ResponseWriter, r *http.Request,
-	s *stream, readerFunc func(u uuid.UUID) (common.ChunkReader, error),
+	s *stream, readerFunc func(instanceID) (common.ChunkReader, error),
 	conversionFunc func(in []byte) ([]byte, error)) {
-	u := mux.Vars(r)["uuid"]
-	uid, err := uuid.FromString(u)
+	var id instanceID
+	var err error
+	uuidStr := mux.Vars(r)["uuid"]
+	id.devUUID, err = uuid.FromString(uuidStr)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
+	}
+	if uuidStr, hasAppUUID := mux.Vars(r)["appuuid"]; hasAppUUID {
+		id.appUUID, err = uuid.FromString(uuidStr)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 	}
 	conversionRequired := false
 	if conversionFunc != nil {
@@ -490,7 +518,7 @@ func (h *adminHandler) deviceDataGet(w http.ResponseWriter, r *http.Request,
 		w.Header().Set("Content-type", "application/json")
 		flusher.Flush()
 
-		c, unsubscribe := s.subscribe(uid)
+		c, unsubscribe := s.subscribe(id)
 		defer unsubscribe()
 
 		for {
@@ -512,7 +540,7 @@ func (h *adminHandler) deviceDataGet(w http.ResponseWriter, r *http.Request,
 		}
 	} else {
 		for {
-			chunk, err := readerFunc(uid)
+			chunk, err := readerFunc(id)
 			_, isNotFound := err.(*common.NotFoundError)
 			switch {
 			case err != nil && isNotFound:

--- a/pkg/server/apiHandler.go
+++ b/pkg/server/apiHandler.go
@@ -24,6 +24,7 @@ type apiHandler struct {
 	infoStream     *stream
 	metricStream   *stream
 	requestsStream *stream
+	flowlogsStream *stream
 }
 
 // GetUser godoc
@@ -317,7 +318,7 @@ func (h *apiHandler) flowLog(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}
-	status, err := flowLogProcess(h.manager, *u, b)
+	status, err := flowLogProcess(h.manager, h.flowlogsStream, *u, b)
 	if err != nil {
 		log.Printf("Failed to logsProcess: %v", err)
 		http.Error(w, http.StatusText(status), status)

--- a/pkg/server/apiHandler.go
+++ b/pkg/server/apiHandler.go
@@ -51,7 +51,7 @@ func (h *apiHandler) recordClient(u *uuid.UUID, r *http.Request) {
 		log.Printf("error saving request structure: %v", err)
 		return
 	}
-	h.requestsStream.publish(*u, b)
+	h.requestsStream.publish(instanceID{devUUID: *u}, b)
 	h.manager.WriteRequest(*u, b)
 }
 
@@ -246,7 +246,7 @@ func (h *apiHandler) appLogs(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}
-	status, err := appLogsProcess(h.manager, *u, uid, b)
+	status, err := appLogsProcess(h.manager, h.logStream, *u, uid, b)
 	if err != nil {
 		log.Printf("Failed to logsProcess: %v", err)
 		http.Error(w, http.StatusText(status), status)
@@ -281,7 +281,7 @@ func (h *apiHandler) newAppLogs(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	status, err := newAppLogsProcess(h.manager, *u, uid, r.Body)
+	status, err := newAppLogsProcess(h.manager, h.logStream, *u, uid, r.Body)
 	if err != nil {
 		log.Printf("Failed to logsProcess: %v", err)
 		http.Error(w, http.StatusText(status), status)

--- a/pkg/server/apiHandlerv2.go
+++ b/pkg/server/apiHandlerv2.go
@@ -81,7 +81,7 @@ func (h *apiHandlerv2) recordClient(u *uuid.UUID, r *http.Request) {
 		log.Printf("error saving request structure: %v", err)
 		return
 	}
-	h.requestsStream.publish(*u, b)
+	h.requestsStream.publish(instanceID{devUUID: *u}, b)
 	h.manager.WriteRequest(*u, b)
 }
 
@@ -613,7 +613,7 @@ func (h *apiHandlerv2) appLogs(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	status, err := appLogsProcess(h.manager, *u, uid, b)
+	status, err := appLogsProcess(h.manager, h.logStream, *u, uid, b)
 	if err != nil {
 		log.Printf("Failed to logsProcess: %v", err)
 		http.Error(w, http.StatusText(status), status)
@@ -632,7 +632,7 @@ func (h *apiHandlerv2) newAppLogs(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	status, err := newAppLogsProcess(h.manager, *u, uid, bytes.NewReader(b))
+	status, err := newAppLogsProcess(h.manager, h.logStream, *u, uid, bytes.NewReader(b))
 	if err != nil {
 		log.Printf("Failed to logsProcess: %v", err)
 		http.Error(w, http.StatusText(status), status)

--- a/pkg/server/apiHandlerv2.go
+++ b/pkg/server/apiHandlerv2.go
@@ -45,6 +45,7 @@ type apiHandlerv2 struct {
 	infoStream      *stream
 	metricStream    *stream
 	requestsStream  *stream
+	flowlogsStream  *stream
 	signingCertPath string
 	signingKeyPath  string
 	encryptCertPath string
@@ -657,7 +658,7 @@ func (h *apiHandlerv2) flowlog(w http.ResponseWriter, r *http.Request) {
 	if u == nil {
 		return
 	}
-	status, err := flowLogProcess(h.manager, *u, b)
+	status, err := flowLogProcess(h.manager, h.flowlogsStream, *u, b)
 	if err != nil {
 		log.Printf("Failed to logsProcess: %v", err)
 		http.Error(w, http.StatusText(status), status)

--- a/pkg/server/commonHandler.go
+++ b/pkg/server/commonHandler.go
@@ -156,7 +156,7 @@ func registerProcess(manager driver.DeviceManager, registerMessage []byte, onboa
 
 func infoProcess(manager driver.DeviceManager, infoStream *stream, u uuid.UUID, infoMessage []byte) (int, error) {
 	var err error
-	infoStream.publish(u, infoMessage)
+	infoStream.publish(instanceID{devUUID: u}, infoMessage)
 	err = manager.WriteInfo(u, infoMessage)
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("failed to write info message: %v", err)
@@ -167,7 +167,7 @@ func infoProcess(manager driver.DeviceManager, infoStream *stream, u uuid.UUID, 
 
 func metricProcess(manager driver.DeviceManager, metricStream *stream, u uuid.UUID, metricMessage []byte) (int, error) {
 	var err error
-	metricStream.publish(u, metricMessage)
+	metricStream.publish(instanceID{devUUID: u}, metricMessage)
 	err = manager.WriteMetrics(u, metricMessage)
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("failed to write metric message: %v", err)
@@ -194,7 +194,7 @@ func logsProcess(manager driver.DeviceManager, logsStream *stream, u uuid.UUID, 
 		if entryBytes, err = entry.Json(); err != nil {
 			return http.StatusBadRequest, fmt.Errorf("failed to marshal FullLogEntry message: %v", err)
 		}
-		logsStream.publish(u, entryBytes)
+		logsStream.publish(instanceID{devUUID: u}, entryBytes)
 		err = manager.WriteLogs(u, entryBytes)
 		if err != nil {
 			return http.StatusInternalServerError, fmt.Errorf("failed to write logs message: %v", err)
@@ -228,7 +228,7 @@ func newLogsProcess(manager driver.DeviceManager, logsStream *stream, u uuid.UUI
 		if entryBytes, err = entry.Json(); err != nil {
 			return http.StatusBadRequest, fmt.Errorf("failed to marshal FullLogEntry message: %v", err)
 		}
-		logsStream.publish(u, entryBytes)
+		logsStream.publish(instanceID{devUUID: u}, entryBytes)
 		err = manager.WriteLogs(u, entryBytes)
 		if err != nil {
 			return http.StatusInternalServerError, fmt.Errorf("failed to write logs message: %v", err)
@@ -238,7 +238,8 @@ func newLogsProcess(manager driver.DeviceManager, logsStream *stream, u uuid.UUI
 	return http.StatusCreated, nil
 }
 
-func appLogsProcess(manager driver.DeviceManager, u, appID uuid.UUID, logsMessage []byte) (int, error) {
+func appLogsProcess(manager driver.DeviceManager, logsStream *stream,
+	devID, appID uuid.UUID, logsMessage []byte) (int, error) {
 	msg := &logs.AppInstanceLogBundle{}
 	if err := proto.Unmarshal(logsMessage, msg); err != nil {
 		return http.StatusBadRequest, fmt.Errorf("error parsing appinstancelogbundle message: %v", err)
@@ -249,7 +250,8 @@ func appLogsProcess(manager driver.DeviceManager, u, appID uuid.UUID, logsMessag
 		if b, err = protojson.Marshal(le); err != nil {
 			return http.StatusBadRequest, fmt.Errorf("failed to marshal LogEntry message: %v", err)
 		}
-		err = manager.WriteAppInstanceLogs(appID, u, b)
+		logsStream.publish(instanceID{devUUID: devID, appUUID: appID}, b)
+		err = manager.WriteAppInstanceLogs(appID, devID, b)
 		if err != nil {
 			return http.StatusInternalServerError, fmt.Errorf("failed to write appinstancelogbundle message: %v", err)
 		}
@@ -258,7 +260,8 @@ func appLogsProcess(manager driver.DeviceManager, u, appID uuid.UUID, logsMessag
 	return http.StatusCreated, nil
 }
 
-func newAppLogsProcess(manager driver.DeviceManager, u, appID uuid.UUID, reader io.Reader) (int, error) {
+func newAppLogsProcess(manager driver.DeviceManager, logsStream *stream,
+	devID, appID uuid.UUID, reader io.Reader) (int, error) {
 	gr, err := gzip.NewReader(reader)
 	if err != nil {
 		return http.StatusBadRequest, fmt.Errorf("error gzip.NewReader: %v", err)
@@ -273,7 +276,8 @@ func newAppLogsProcess(manager driver.DeviceManager, u, appID uuid.UUID, reader 
 		if b, err = protojson.Marshal(le); err != nil {
 			return http.StatusBadRequest, fmt.Errorf("failed to marshal LogEntry message: %v", err)
 		}
-		err = manager.WriteAppInstanceLogs(appID, u, b)
+		logsStream.publish(instanceID{devUUID: devID, appUUID: appID}, b)
+		err = manager.WriteAppInstanceLogs(appID, devID, b)
 		if err != nil {
 			return http.StatusInternalServerError, fmt.Errorf("failed to write logs message: %v", err)
 		}

--- a/pkg/server/commonHandler.go
+++ b/pkg/server/commonHandler.go
@@ -325,8 +325,10 @@ func randomString(length int) string {
 	return fmt.Sprintf("%x", b)[:length]
 }
 
-func flowLogProcess(manager driver.DeviceManager, u uuid.UUID, flowMessage []byte) (int, error) {
+func flowLogProcess(manager driver.DeviceManager, flowlogsStream *stream,
+	u uuid.UUID, flowMessage []byte) (int, error) {
 	var err error
+	flowlogsStream.publish(instanceID{devUUID: u}, flowMessage)
 	err = manager.WriteFlowMessage(u, flowMessage)
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("failed to write FlowMessage: %v", err)

--- a/pkg/server/commonHandler.go
+++ b/pkg/server/commonHandler.go
@@ -25,7 +25,9 @@ import (
 	"github.com/lf-edge/adam/pkg/driver"
 	"github.com/lf-edge/adam/pkg/driver/common"
 	"github.com/lf-edge/eve-api/go/config"
+	"github.com/lf-edge/eve-api/go/info"
 	"github.com/lf-edge/eve-api/go/logs"
+	"github.com/lf-edge/eve-api/go/metrics"
 	"github.com/lf-edge/eve-api/go/register"
 	uuid "github.com/satori/go.uuid"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -155,24 +157,34 @@ func registerProcess(manager driver.DeviceManager, registerMessage []byte, onboa
 }
 
 func infoProcess(manager driver.DeviceManager, infoStream *stream, u uuid.UUID, infoMessage []byte) (int, error) {
-	var err error
-	infoStream.publish(instanceID{devUUID: u}, infoMessage)
-	err = manager.WriteInfo(u, infoMessage)
+	msg := &info.ZInfoMsg{}
+	if err := proto.Unmarshal(infoMessage, msg); err != nil {
+		return http.StatusBadRequest, fmt.Errorf("error parsing info message: %v", err)
+	}
+	jsonBytes, err := protojson.Marshal(msg)
 	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("failed to marshal info to json: %v", err)
+	}
+	infoStream.publish(instanceID{devUUID: u}, jsonBytes)
+	if err := manager.WriteInfo(u, append(jsonBytes, '\n')); err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("failed to write info message: %v", err)
 	}
-	// send back a 201
 	return http.StatusCreated, nil
 }
 
 func metricProcess(manager driver.DeviceManager, metricStream *stream, u uuid.UUID, metricMessage []byte) (int, error) {
-	var err error
-	metricStream.publish(instanceID{devUUID: u}, metricMessage)
-	err = manager.WriteMetrics(u, metricMessage)
+	msg := &metrics.ZMetricMsg{}
+	if err := proto.Unmarshal(metricMessage, msg); err != nil {
+		return http.StatusBadRequest, fmt.Errorf("error parsing metrics message: %v", err)
+	}
+	jsonBytes, err := protojson.Marshal(msg)
 	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("failed to marshal metrics to json: %v", err)
+	}
+	metricStream.publish(instanceID{devUUID: u}, jsonBytes)
+	if err := manager.WriteMetrics(u, append(jsonBytes, '\n')); err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("failed to write metric message: %v", err)
 	}
-	// send back a 201
 	return http.StatusCreated, nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -95,6 +95,7 @@ func (s *Server) Start() {
 	infoStream := &stream{}
 	metricStream := &stream{}
 	requestsStream := &stream{}
+	flowlogsStream := &stream{}
 
 	// edgedevice endpoint - fully compliant with EVE open API
 	api := &apiHandler{
@@ -103,6 +104,7 @@ func (s *Server) Start() {
 		infoStream:     infoStream,
 		metricStream:   metricStream,
 		requestsStream: requestsStream,
+		flowlogsStream: flowlogsStream,
 	}
 
 	router.HandleFunc("/probe", api.probe).Methods("GET")
@@ -130,6 +132,7 @@ func (s *Server) Start() {
 			infoStream:      infoStream,
 			metricStream:    metricStream,
 			requestsStream:  requestsStream,
+			flowlogsStream:  flowlogsStream,
 			signingCertPath: s.SigningCertPath,
 			signingKeyPath:  s.SigningKeyPath,
 			encryptCertPath: s.EncryptCertPath,
@@ -164,6 +167,7 @@ func (s *Server) Start() {
 		infoStream:     infoStream,
 		requestsStream: requestsStream,
 		metricsStream:  metricStream,
+		flowlogsStream: flowlogsStream,
 	}
 
 	ad := router.PathPrefix("/admin").Subrouter()
@@ -197,6 +201,7 @@ func (s *Server) Start() {
 	ad.HandleFunc("/device/{uuid}/metrics", admin.deviceMetricsGet).Methods("GET")
 	ad.HandleFunc("/device/{uuid}/certs", admin.deviceCertsGet).Methods("GET")
 	ad.HandleFunc("/device/{uuid}/app/{appuuid}/logs", admin.appLogsGet).Methods("GET")
+	ad.HandleFunc("/device/{uuid}/flowlogs", admin.deviceFlowlogsGet).Methods("GET")
 	ad.HandleFunc("/device", admin.deviceAdd).Methods("POST")
 	ad.HandleFunc("/device", admin.deviceClear).Methods("DELETE")
 	ad.HandleFunc("/device/{uuid}", admin.deviceRemove).Methods("DELETE")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -196,6 +196,7 @@ func (s *Server) Start() {
 	ad.HandleFunc("/device/{uuid}/requests", admin.deviceRequestsGet).Methods("GET")
 	ad.HandleFunc("/device/{uuid}/metrics", admin.deviceMetricsGet).Methods("GET")
 	ad.HandleFunc("/device/{uuid}/certs", admin.deviceCertsGet).Methods("GET")
+	ad.HandleFunc("/device/{uuid}/app/{appuuid}/logs", admin.appLogsGet).Methods("GET")
 	ad.HandleFunc("/device", admin.deviceAdd).Methods("POST")
 	ad.HandleFunc("/device", admin.deviceClear).Methods("DELETE")
 	ad.HandleFunc("/device/{uuid}", admin.deviceRemove).Methods("DELETE")

--- a/pkg/server/stream.go
+++ b/pkg/server/stream.go
@@ -9,12 +9,20 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-// stream manages in-memory pub/sub of byte streams per device UUID.
-// Subscribers register per device and receive published data over a channel.
+// stream manages in-memory pub/sub of byte streams per device/app UUID.
+// Subscribers register per device/app and receive published data over a channel.
 // Publishing is non-blocking; slow subscribers will have data dropped.
 type stream struct {
 	sync.RWMutex
-	subscribers map[uuid.UUID][]streamSubscriber // key: device UUID
+	subscribers map[instanceID][]streamSubscriber
+}
+
+type instanceID struct {
+	// mandatory
+	devUUID uuid.UUID
+
+	// optional, leave empty when identifying device as a whole
+	appUUID uuid.UUID
 }
 
 // streamSubscriber represents a single subscriber of a device stream.
@@ -24,14 +32,14 @@ type streamSubscriber struct {
 	channel chan []byte
 }
 
-// publish delivers data to all subscribers registered for the given device.
+// publish delivers data to all subscribers registered for the given device/app.
 // Delivery is non-blocking; if a subscriber's channel buffer is full,
 // the message is dropped for that subscriber.
-func (s *stream) publish(devID uuid.UUID, data []byte) {
+func (s *stream) publish(id instanceID, data []byte) {
 	s.RLock()
 	defer s.RUnlock()
 
-	for _, sub := range s.subscribers[devID] {
+	for _, sub := range s.subscribers[id] {
 		select {
 		case sub.channel <- data:
 		default:
@@ -40,23 +48,23 @@ func (s *stream) publish(devID uuid.UUID, data []byte) {
 	}
 }
 
-// subscribe registers a new subscriber for the given device.
+// subscribe registers a new subscriber for the given device/app.
 // It returns:
 //   - a read-only channel on which published data is delivered
 //   - an unsubscribe function that removes the subscriber (idempotent)
 //
 // The returned unsubscribe function is safe to call multiple times.
-func (s *stream) subscribe(devID uuid.UUID) (<-chan []byte, func()) {
+func (s *stream) subscribe(id instanceID) (<-chan []byte, func()) {
 	s.Lock()
 	if s.subscribers == nil {
-		s.subscribers = make(map[uuid.UUID][]streamSubscriber)
+		s.subscribers = make(map[instanceID][]streamSubscriber)
 	}
 
 	sub := streamSubscriber{
 		channel: make(chan []byte, 100),
 	}
 
-	s.subscribers[devID] = append(s.subscribers[devID], sub)
+	s.subscribers[id] = append(s.subscribers[id], sub)
 	s.Unlock()
 
 	var once sync.Once
@@ -66,18 +74,18 @@ func (s *stream) subscribe(devID uuid.UUID) (<-chan []byte, func()) {
 			s.Lock()
 			defer s.Unlock()
 
-			subs := s.subscribers[devID]
+			subs := s.subscribers[id]
 			for i := range subs {
 				if subs[i].channel == sub.channel {
 					// Remove subscriber from the list.
-					s.subscribers[devID] = append(subs[:i], subs[i+1:]...)
+					s.subscribers[id] = append(subs[:i], subs[i+1:]...)
 					break
 				}
 			}
 
 			// Clean up empty slice to avoid map growth.
-			if len(s.subscribers[devID]) == 0 {
-				delete(s.subscribers, devID)
+			if len(s.subscribers[id]) == 0 {
+				delete(s.subscribers, id)
 			}
 
 			close(sub.channel)


### PR DESCRIPTION
The [eden](https://github.com/lf-edge/eden) testing framework currently retrieves app logs and flow records by directly reading Adam's on-disk database. This couples eden to Adam's internal storage layout and makes it fragile to any change in how Adam stores data. This PR adds proper admin API endpoints for both data types so that external tools can fetch them through Adam's public interface.

- Add `GET /admin/device/{uuid}/app/{appuuid}/logs`: returns accumulated app instance logs or streams them in real time (via `Stream: true` header), consistent with the existing device-level log/info/metric endpoints.
- Add `GET /admin/device/{uuid}/flowlogs`: same one-shot/streaming semantics for flow records.
- Extend the `DeviceManager` interface with `GetAppLogsReader` and `GetFlowMessageReader`; implement both in the File, Memory, and Redis drivers.
- Generalize the in-memory pub/sub stream to key subscribers by an `instanceID` (device UUID + optional app UUID), enabling per-app streaming without a separate stream object per endpoint.
- Unify storage format: info and metrics are now converted to JSON at write time (matching logs and app logs), removing the read-time `conversionFunc` callback from `deviceDataGet` and fixing a silent data-loss bug in the file driver where concatenated protobuf messages were not self-delimiting.
- Fix two file driver bugs where required subdirectories (`app/<uuid>/logs`, `flow_message`) were never created on disk, causing the first write to fail with "no such file or directory".
- Fix `openTimestampFile` which used `.111` as a Go time-format literal (not milliseconds), causing files created within the same second to overwrite each other.