### PR TITLE
server: populate EdgeDevConfig.controllercert_confighash

### DIFF
--- a/pkg/server/apiHandler.go
+++ b/pkg/server/apiHandler.go
@@ -129,7 +129,8 @@ func (h *apiHandler) configPost(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
-	data, code, err := configProcess(h.manager, *u, configRequest, cfg, false)
+	// v1 API: no controller cert chain, pass empty hash.
+	data, code, err := configProcess(h.manager, *u, configRequest, cfg, false, "")
 	if err != nil {
 		log.Printf("error configProcess: %v", err)
 		http.Error(w, http.StatusText(code), code)

--- a/pkg/server/apiHandlerv2.go
+++ b/pkg/server/apiHandlerv2.go
@@ -159,6 +159,28 @@ func (h *apiHandlerv2) getAllCerts() (map[string]*certs.ZCert, error) {
 	return allCerts, nil
 }
 
+// controllerCertConfigHash returns a base64-URL-encoded sha256 over the
+// concatenated raw bytes of the signing and encryption cert files. The
+// value is opaque - EVE only compares it to its previously-saved value
+// via handleControllerCertsSha and triggers a /certs refetch when it
+// changes. Any rotation of either file flips the hash.
+//
+// We intentionally hash the file bytes (not the parsed/trimmed cert)
+// because a missing or unreadable file is itself a meaningful state
+// transition: when EVE refetches /certs in response, it gets the
+// current content (which getAllCerts already TrimSpace's).
+func (h *apiHandlerv2) controllerCertConfigHash() string {
+	hasher := sha256.New()
+	for _, p := range []string{h.signingCertPath, h.encryptCertPath} {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		hasher.Write(data)
+	}
+	return base64.URLEncoding.EncodeToString(hasher.Sum(nil))
+}
+
 func verifySignature(signature, payloadHash []byte, cert *x509.Certificate) error {
 
 	switch pub := cert.PublicKey.(type) {
@@ -506,7 +528,7 @@ func (h *apiHandlerv2) config(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
-	data, code, err := configProcess(h.manager, *u, configRequest, cfg, true)
+	data, code, err := configProcess(h.manager, *u, configRequest, cfg, true, h.controllerCertConfigHash())
 	if err != nil {
 		log.Println(err)
 		http.Error(w, http.StatusText(code), code)

--- a/pkg/server/commonHandler.go
+++ b/pkg/server/commonHandler.go
@@ -66,7 +66,7 @@ func contentTypeJSON(r *http.Request) bool {
 	}
 }
 
-func configProcess(manager driver.DeviceManager, u uuid.UUID, configRequest *config.ConfigRequest, conf []byte, enforceIntegrityCheck bool) ([]byte, int, error) {
+func configProcess(manager driver.DeviceManager, u uuid.UUID, configRequest *config.ConfigRequest, conf []byte, enforceIntegrityCheck bool, controllerCertConfigHash string) ([]byte, int, error) {
 	deviceOptions, err := getDeviceOptions(manager, u)
 	if err != nil {
 		return nil, http.StatusInternalServerError, fmt.Errorf("failed to get device options: %v", err)
@@ -81,6 +81,14 @@ func configProcess(manager driver.DeviceManager, u uuid.UUID, configRequest *con
 	if err := proto.Unmarshal(conf, &msg); err != nil {
 		return nil, http.StatusInternalServerError, fmt.Errorf("error reading device config: %v", err)
 	}
+	// Populate controllercert_confighash so EVE's handleControllerCertsSha
+	// triggers /certs refetch whenever the cert chain changes - including
+	// pure encrypt-cert rotations that don't touch signing.pem and so
+	// don't otherwise raise SenderStatusCertMiss. See lf-edge/eve#5926.
+	// Set this *before* the ConfigHash computation so a cert-chain change
+	// also flips ConfigHash and EVE doesn't get 304 Not Modified.
+	msg.ControllercertConfighash = controllerCertConfigHash
+
 	response := &config.ConfigResponse{}
 
 	hash := sha256.New()


### PR DESCRIPTION
## Summary

Adam never set `EdgeDevConfig.controllercert_confighash` on its config response. EVE's `handleControllerCertsSha` (`pkg/pillar/cmd/zedagent/handlecertconfig.go:622-631`) compares this field against the device's saved value and triggers a `/certs` refetch on mismatch — but with adam emitting the empty string, the trigger was dead. The only fast path to a `/certs` refetch was a signing-cert rotation that raised `SenderStatusCertMiss` from auth-envelope verification.

This made *pure encrypt-cert rotation* effectively unobservable on the device until the periodic `controllerCertsTask` fired (default `CertInterval = 24h`): the cipher decrypt path silently returns "Controller Certificate get fail" without triggering any refetch. See [lf-edge/eve#5926](https://github.com/lf-edge/eve/issues/5926) for the broader gap analysis.

## Change

Compute `base64.URLEncoding.EncodeToString(sha256(signing.pem || encrypt.pem))` and populate `EdgeDevConfig.controllercert_confighash`. Any rotation of either file flips the hash, EVE compares, schedules a refetch.

The hash is opaque to EVE — only equality matters — so hashing the raw file bytes is sufficient and avoids cert parsing. The field is set *before* `ConfigHash` is computed so a cert-chain rotation also flips `ConfigHash`; otherwise adam would return 304 Not Modified for any pure cert rotation that didn't otherwise change the device config and EVE would never see the new field.

The v1 API path passes an empty hash (v1 has no controller cert chain).

## Test plan

- [ ] `go build ./...` clean.
- [ ] `gofmt -l pkg/server/` clean.
- [ ] `go test ./pkg/server/...` passes (no test files in this package today).
- [ ] Manual: with this build of adam, run [lf-edge/eden#1163](https://github.com/lf-edge/eden/pull/1163)'s `ctrl_encrypt_cert_change` rotating *only* the encrypt cert (no signing rotation). Verify a freshly-deployed `--use-encrypt-cert` app reaches RUNNING — proves EVE refetched `/certs` via `handleControllerCertsSha` and decrypted with the new ECDH key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)