### PR TITLE
Dockerfile.local: place COPY targets under /out

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -3,9 +3,9 @@ ENV PKGS alpine-baselayout
 RUN eve-alpine-deploy.sh
 
 WORKDIR /out
-COPY scripts /bin
-COPY samples /adam
-COPY ./bin/adam-linux-amd64 /bin/adam
+COPY scripts /out/bin/
+COPY samples /out/adam/
+COPY ./bin/adam-linux-amd64 /out/bin/adam
 
 FROM scratch
 COPY --from=build /out/ /


### PR DESCRIPTION
## Summary

`make image-local` (documented in `README.md` as the recommended quick
reproducible build path) currently produces an image without
`/bin/adam`. Running such an image fails immediately with:

```
"/bin/adam": stat /bin/adam: no such file or directory
```

## Root cause

`Dockerfile.local`'s build stage sets `WORKDIR /out` but the three
`COPY` directives target absolute paths at root:

```dockerfile
WORKDIR /out
COPY scripts /bin
COPY samples /adam
COPY ./bin/adam-linux-amd64 /bin/adam
```

Absolute paths in `COPY` are *not* joined with `WORKDIR`, so the
files land at `/bin`, `/adam`, and `/bin/adam` in the build stage's
filesystem.

The final scratch stage then does:

```dockerfile
FROM scratch
COPY --from=build /out/ /
```

…which copies only what's under `/out/`. The scripts, samples, and
adam binary at the build-stage root are silently dropped from the
final image.

The non-`.local` `Dockerfile` (used for CI / Docker Hub builds) does
this correctly — `RUN go build -o /out/bin/adam main.go`,
`COPY scripts/ /out/bin/`, `COPY samples/ /out/adam/`. Only
`Dockerfile.local` has the bug.

## Fix

Redirect the three COPY destinations to `/out/bin/`, `/out/adam/`,
and `/out/bin/adam` so the scratch stage picks them up.

## How to test

Before this patch, on master HEAD:

```sh
make build                 # produce bin/adam-linux-amd64
make image-local IMG=lfedge/adam:test
docker run --rm --entrypoint=/bin/sh lfedge/adam:test -c 'ls /bin/adam'
# → ls: /bin/adam: No such file or directory
```

After this patch:

```sh
docker run --rm --entrypoint=/bin/sh lfedge/adam:test -c 'ls -la /bin/adam'
# → -rwxr-xr-x 1 root root 21998444 … /bin/adam
docker run --rm --entrypoint=/bin/sh lfedge/adam:test -c 'ls /adam/'
# → simple.json … (samples present)
```

The actual `make image-local` flow (which calls `make build` first on
my local machine has an unrelated go.mod-version vs. pinned-golang
issue), but the Dockerfile change itself is independently verifiable
by building it directly with a pre-existing `bin/adam-linux-amd64`,
which I've done locally as shown above.