### PR TITLE
server: optional log of served device config

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,29 @@ Finally, you can embed Adam container into an EVE root filesystem creating an EV
      net: host
 ```
 
+### Debug logging
+
+Adam logs every API request it receives. For investigations where you
+also need to see what was *returned* to the device on each `/config`
+poll, set `ADAM_LOG_DEVICE_CONFIG=1` in adam's environment. With this
+on, every served device config produces a one-line summary on stderr:
+
+```
+config served: uuid=<UUID> version=<N> baseos.version=<V> baseos.activate=<bool> \
+    baseos.ct=<content-tree-UUID> baseosconfig_list=<n> contentInfo=<n> apps=<n> \
+    networks=<n> volumes=<n> datastores=<n>
+```
+
+The variable is off by default; turning it on adds one log line per
+`/config` poll per device, which is modest at typical poll intervals
+(~30 s) but multiplies across N devices.
+
+For example, with `docker run`:
+
+```
+docker run -e ADAM_LOG_DEVICE_CONFIG=1 lfedge/adam server
+```
+
 ## Controlling Adam
 
 Adam provides a CLI management interface and Web UI, both of which wrap an open management API.

--- a/pkg/server/commonHandler.go
+++ b/pkg/server/commonHandler.go
@@ -17,6 +17,7 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -88,6 +89,28 @@ func configProcess(manager driver.DeviceManager, u uuid.UUID, configRequest *con
 	// Set this *before* the ConfigHash computation so a cert-chain change
 	// also flips ConfigHash and EVE doesn't get 304 Not Modified.
 	msg.ControllercertConfighash = controllerCertConfigHash
+
+	// Optional debug trace of what we're about to serve. Off by
+	// default; set ADAM_LOG_DEVICE_CONFIG=1 to enable when investigating
+	// "what did adam tell EVE on this poll?" questions. Fires before the
+	// 304 Not Modified check so it surfaces the response shape even on
+	// no-change polls.
+	if os.Getenv("ADAM_LOG_DEVICE_CONFIG") == "1" {
+		var bosVer, bosCTUUID string
+		var bosAct bool
+		if msg.Baseos != nil {
+			bosVer = msg.Baseos.BaseOsVersion
+			bosAct = msg.Baseos.Activate
+			bosCTUUID = msg.Baseos.ContentTreeUuid
+		}
+		log.Printf("config served: uuid=%s version=%s baseos.version=%q "+
+			"baseos.activate=%v baseos.ct=%q baseosconfig_list=%d "+
+			"contentInfo=%d apps=%d networks=%d volumes=%d datastores=%d",
+			u, msg.GetId().GetVersion(),
+			bosVer, bosAct, bosCTUUID,
+			len(msg.Base), len(msg.ContentInfo), len(msg.Apps),
+			len(msg.Networks), len(msg.Volumes), len(msg.Datastores))
+	}
 
 	response := &config.ConfigResponse{}
 


### PR DESCRIPTION
## Summary

Adam logs every inbound API request (`requested /api/v2/edgedevice/id/<UUID>/config`).
For investigations where you also need to see what was *returned* —
which baseos, which content tree, how many apps/networks etc. — the
request log alone isn't enough.

This PR adds a one-line response summary, gated by an env var so the
default log volume is unchanged.

## Behaviour

With `ADAM_LOG_DEVICE_CONFIG=1` set, every served device config emits
on stderr:

```
config served: uuid=<UUID> version=<N> baseos.version=<V> \
    baseos.activate=<bool> baseos.ct=<UUID> baseosconfig_list=<n> \
    contentInfo=<n> apps=<n> networks=<n> volumes=<n> datastores=<n>
```

Off by default → no log-volume cost for normal operators.

The log fires *before* the `304 Not Modified` short-circuit so it
surfaces the response shape on every poll, even those where EVE
already has the current config. That makes it useful for "is EVE
even polling for /config right now?" questions, not just "what's in
the response?".

## How to enable

```sh
# bare adam
ADAM_LOG_DEVICE_CONFIG=1 adam server

# adam container
docker run -e ADAM_LOG_DEVICE_CONFIG=1 lfedge/adam server

# eden-managed adam
docker run -e ADAM_LOG_DEVICE_CONFIG=1 ... lfedge/adam:<tag> ...
```

`docker logs eden_adam` (or wherever stderr lands) then carries one
`config served:` line per `/config` poll.

## Field choice

The fields cover the categories the response body decomposes into —
baseos block, baseos list (legacy), contentInfo, apps, networks,
volumes, datastores. Each is summarised by either a key fact
(baseos: version + activate + content-tree UUID) or a count (lists).
That keeps the line a single grep target while still answering the
common debugging questions:

- "Did adam send a baseos this poll?" — `baseos.version`
- "Is it asking EVE to install it?" — `baseos.activate`
- "Why does my contentInfo count differ across polls?" — `contentInfo=N`
- "How long since the controller's last edit?" — `version=N`

## Test

```sh
make build
ADAM_LOG_DEVICE_CONFIG=1 ./bin/adam-linux-amd64 server ...   # then poll /config
# observe one "config served: uuid=..." line per poll on stderr
unset ADAM_LOG_DEVICE_CONFIG
./bin/adam-linux-amd64 server ...                            # poll /config
# observe no extra log lines (only the existing request-line)
```

Unit tests (`go test ./...`) pass.