### PR TITLE
server: return 403 on unregistered onboarding cert/serial

### DIFF
--- a/pkg/server/commonHandler.go
+++ b/pkg/server/commonHandler.go
@@ -132,7 +132,14 @@ func registerProcess(manager driver.DeviceManager, registerMessage []byte, onboa
 			_, usedSerial := err.(*common.UsedSerialError)
 			switch {
 			case invalidCert, invalidSerial:
-				return http.StatusUnauthorized, fmt.Errorf("failed authentication %v", err)
+				// The auth-container signature already verified upstream
+				// (apiHandlerv2.register checks SenderCertHash and the
+				// signature before calling here); a well-formed cert or
+				// serial that is simply not pre-registered is the
+				// "valid credentials without authorization" case the
+				// eve-api spec maps to 403 (APIv2.md, /register section
+				// and the table at lines 134-142).
+				return http.StatusForbidden, fmt.Errorf("not pre-registered %v", err)
 			case usedSerial:
 				return http.StatusConflict, fmt.Errorf("used serial %v", err)
 			}

--- a/pkg/server/commonHandler_test.go
+++ b/pkg/server/commonHandler_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"crypto/x509"
+	"net/http"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/lf-edge/adam/pkg/driver/memory"
+	ax "github.com/lf-edge/adam/pkg/x509"
+	"github.com/lf-edge/eve-api/go/register"
+)
+
+// TestRegisterProcessForbiddenForUnknownCert verifies that when the
+// auth-container signature has already verified upstream but the (cert,
+// serial) tuple is not in the controller's pre-registration set,
+// registerProcess returns 403 Forbidden — per APIv2.md /register:
+// "Valid credentials without authorization: 403".
+//
+// Prior to this fix the same condition mapped to 401 Unauthorized, which
+// confused "missing/invalid credentials" with "valid credentials, not
+// pre-registered" and prevented EVE's cmd/client from raising
+// LedBlinkOnboardingFailureNotFound (which is keyed off 403).
+func TestRegisterProcessForbiddenForUnknownCert(t *testing.T) {
+	dm := &memory.DeviceManager{}
+
+	certB, _, err := ax.Generate("CN=test-onboard", "")
+	if err != nil {
+		t.Fatalf("generate cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(certB)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+
+	msg := &register.ZRegisterMsg{Serial: "test-serial"}
+	msgBytes, err := proto.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal register message: %v", err)
+	}
+
+	status, err := registerProcess(dm, msgBytes, cert)
+	if status != http.StatusForbidden {
+		t.Errorf("status: got %d, want %d (%s)", status, http.StatusForbidden, http.StatusText(http.StatusForbidden))
+	}
+	if err == nil {
+		t.Error("err: got nil, want non-nil (failure should carry context)")
+	}
+}


### PR DESCRIPTION
## Summary

The `/register` handler currently returns 401 Unauthorized when the
auth-container signature has already verified but the
(onboarding-cert, serial) combination is not in the controller's
pre-registration set. APIv2.md prescribes 403 Forbidden for that
case: "Valid credentials without authorization" (`/register` table)
and lines 159-160 state the response "MUST" be 403 when the
controller requires pre-registration and a device tries to register
without one.

401 remains in `apiHandlerv2.register` for the upstream cryptographic
failures: missing `SenderCertHash`, malformed sender cert, signature
mismatch. The change here is confined to the post-auth authorization
decision in `registerProcess`.

EVE's `pkg/pillar/cmd/client/client.go` already maps 403 to
`LedBlinkOnboardingFailureNotFound` and carries an `XXX` comment
flagging that the controller side of the spec is not yet honoured;
this PR removes that gap. Older EVE that does not special-case 403
falls back to the generic "Registration failed" log path, same as
it does today for 401 — no regression.

## Test plan

- [x] New unit test `TestRegisterProcessForbiddenForUnknownCert` in
      `pkg/server/commonHandler_test.go` calls `registerProcess`
      against an empty `memory.DeviceManager` and asserts a 403 status.
- [x] `go test ./pkg/server/ ./pkg/driver/... -count=1` passes
      (`pkg/server`, `pkg/driver/file`, `pkg/driver/memory`,
      `pkg/driver/redis`).
- [ ] Eden e2e: paired test `server_returns_403` in lf-edge/eden
      (`tests/onboarding/`) verifies EVE raises
      `LedBlinkOnboardingFailureNotFound` when adam returns 403 for
      an unregistered onboarding cert. To be added once this PR lands.