### PR TITLE
Store flow logs as JSON, matching info/metrics

### DIFF
--- a/pkg/server/commonHandler.go
+++ b/pkg/server/commonHandler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/lf-edge/adam/pkg/driver"
 	"github.com/lf-edge/adam/pkg/driver/common"
 	"github.com/lf-edge/eve-api/go/config"
+	"github.com/lf-edge/eve-api/go/flowlog"
 	"github.com/lf-edge/eve-api/go/info"
 	"github.com/lf-edge/eve-api/go/logs"
 	"github.com/lf-edge/eve-api/go/metrics"
@@ -385,12 +386,17 @@ func randomString(length int) string {
 
 func flowLogProcess(manager driver.DeviceManager, flowlogsStream *stream,
 	u uuid.UUID, flowMessage []byte) (int, error) {
-	var err error
-	flowlogsStream.publish(instanceID{devUUID: u}, flowMessage)
-	err = manager.WriteFlowMessage(u, flowMessage)
+	msg := &flowlog.FlowMessage{}
+	if err := proto.Unmarshal(flowMessage, msg); err != nil {
+		return http.StatusBadRequest, fmt.Errorf("error parsing FlowMessage: %v", err)
+	}
+	jsonBytes, err := protojson.Marshal(msg)
 	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("failed to marshal FlowMessage to json: %v", err)
+	}
+	flowlogsStream.publish(instanceID{devUUID: u}, jsonBytes)
+	if err := manager.WriteFlowMessage(u, append(jsonBytes, '\n')); err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("failed to write FlowMessage: %v", err)
 	}
-	// send back a 201
 	return http.StatusCreated, nil
 }


### PR DESCRIPTION
`flowLogProcess` still wrote raw protobuf `FlowMessage` bytes. With the file driver, multiple messages accumulate in the same file, and concatenated protobuf messages are not self-delimiting -- worse, `FlowMessage`'s `DevId` field (number 1, wire type 2) has tag byte `0x0A`, the same byte `deviceDataGet` appends as a chunk separator when serving GET requests, so naive newline-splitting on the client side would routinely split messages mid-field.

Convert to JSON at write time instead, the same treatment applied to info/metrics in 3af1f4114f30ab99233d1a0dbc2490d505fa5475.